### PR TITLE
Provide a way to call into_owned on elements

### DIFF
--- a/src/elements/block.rs
+++ b/src/elements/block.rs
@@ -142,7 +142,7 @@ impl<'a> RawBlock<'a> {
 }
 
 /// Special Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SpecialBlock<'a> {
@@ -171,7 +171,7 @@ impl SpecialBlock<'_> {
 }
 
 /// Quote Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct QuoteBlock<'a> {
@@ -197,7 +197,7 @@ impl QuoteBlock<'_> {
 }
 
 /// Center Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct CenterBlock<'a> {
@@ -223,7 +223,7 @@ impl CenterBlock<'_> {
 }
 
 /// Verse Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct VerseBlock<'a> {
@@ -249,7 +249,7 @@ impl VerseBlock<'_> {
 }
 
 /// Comment Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct CommentBlock<'a> {
@@ -273,7 +273,7 @@ impl CommentBlock<'_> {
 }
 
 /// Example Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ExampleBlock<'a> {
@@ -297,7 +297,7 @@ impl ExampleBlock<'_> {
 }
 
 /// Export Block Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ExportBlock<'a> {
@@ -320,7 +320,7 @@ impl ExportBlock<'_> {
 }
 
 /// Src Block Element
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SourceBlock<'a> {

--- a/src/elements/clock.rs
+++ b/src/elements/clock.rs
@@ -16,7 +16,7 @@ use crate::parse::combinators::{blank_lines_count, eol};
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(untagged))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Clock<'a> {
     /// Closed Clock
     Closed {

--- a/src/elements/comment.rs
+++ b/src/elements/comment.rs
@@ -7,7 +7,7 @@ use nom::{
 
 use crate::parse::combinators::{blank_lines_count, lines_while};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Comment<'a> {
     /// Comments value, with pound signs

--- a/src/elements/cookie.rs
+++ b/src/elements/cookie.rs
@@ -13,7 +13,7 @@ use nom::{
 /// Statistics Cookie Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Cookie<'a> {
     /// Full cookie value
     pub value: Cow<'a, str>,

--- a/src/elements/drawer.rs
+++ b/src/elements/drawer.rs
@@ -11,7 +11,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, eol, lines_till};
 
 /// Drawer Element
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Drawer<'a> {

--- a/src/elements/dyn_block.rs
+++ b/src/elements/dyn_block.rs
@@ -10,7 +10,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, line, lines_till};
 
 /// Dynamic Block Element
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct DynBlock<'a> {

--- a/src/elements/fixed_width.rs
+++ b/src/elements/fixed_width.rs
@@ -7,7 +7,7 @@ use nom::{
 
 use crate::parse::combinators::{blank_lines_count, lines_while};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct FixedWidth<'a> {

--- a/src/elements/fn_def.rs
+++ b/src/elements/fn_def.rs
@@ -12,7 +12,7 @@ use crate::parse::combinators::{blank_lines_count, line};
 /// Footnote Definition Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct FnDef<'a> {
     /// Footnote label, used for reference
     pub label: Cow<'a, str>,

--- a/src/elements/fn_ref.rs
+++ b/src/elements/fn_ref.rs
@@ -12,7 +12,7 @@ use nom::{
 /// Footnote Reference Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FnRef<'a> {
     /// Footnote label
     pub label: Cow<'a, str>,

--- a/src/elements/inline_call.rs
+++ b/src/elements/inline_call.rs
@@ -11,7 +11,7 @@ use nom::{
 /// Inline Babel Call Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct InlineCall<'a> {
     /// Called code block name
     pub name: Cow<'a, str>,

--- a/src/elements/inline_src.rs
+++ b/src/elements/inline_src.rs
@@ -11,7 +11,7 @@ use nom::{
 /// Inline Src Block Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InlineSrc<'a> {
     /// Language of the code
     pub lang: Cow<'a, str>,

--- a/src/elements/keyword.rs
+++ b/src/elements/keyword.rs
@@ -83,7 +83,7 @@ impl<'a> RawKeyword<'a> {
 /// Keyword Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Keyword<'a> {
     /// Keyword name
     pub key: Cow<'a, str>,
@@ -108,7 +108,7 @@ impl Keyword<'_> {
 }
 
 /// Babel Call Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct BabelCall<'a> {

--- a/src/elements/link.rs
+++ b/src/elements/link.rs
@@ -11,7 +11,7 @@ use nom::{
 /// Link Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Link<'a> {
     /// Link destination
     pub path: Cow<'a, str>,

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -15,7 +15,7 @@ use nom::{
 /// Plain List Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct List {
     /// List indent, number of whitespaces
     pub indent: usize,
@@ -29,7 +29,7 @@ pub struct List {
 /// List Item Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ListItem<'a> {
     /// List item bullet
     pub bullet: Cow<'a, str>,

--- a/src/elements/macros.rs
+++ b/src/elements/macros.rs
@@ -11,7 +11,7 @@ use nom::{
 /// Macro Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Macros<'a> {
     /// Macro name
     pub name: Cow<'a, str>,

--- a/src/elements/planning.rs
+++ b/src/elements/planning.rs
@@ -5,7 +5,7 @@ use crate::elements::Timestamp;
 /// Planning element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Planning<'a> {
     /// Timestamp associated to deadline keyword
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]

--- a/src/elements/rule.rs
+++ b/src/elements/rule.rs
@@ -4,7 +4,7 @@ use nom::{
 
 use crate::parse::combinators::{blank_lines_count, eol};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Rule {

--- a/src/elements/snippet.rs
+++ b/src/elements/snippet.rs
@@ -10,7 +10,7 @@ use nom::{
 /// Export Snippet Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Snippet<'a> {
     /// Back-end name
     pub name: Cow<'a, str>,

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -8,7 +8,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, line, lines_while};
 
 /// Table Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_type"))]
@@ -116,7 +116,7 @@ impl Table<'_> {
 /// |-----+-----+-----| <- ignores
 /// ```
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_row_type"))]
@@ -133,7 +133,7 @@ pub enum TableRow {
 }
 
 /// Table Cell Element
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_cell_type"))]

--- a/src/elements/target.rs
+++ b/src/elements/target.rs
@@ -11,7 +11,7 @@ use nom::{
 /// Target Object
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Target<'a> {
     /// Target ID
     pub target: Cow<'a, str>,

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -100,7 +100,7 @@ mod chrono {
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "ser", serde(tag = "timestamp_type"))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Timestamp<'a> {
     Active {
         start: Datetime<'a>,

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -23,7 +23,7 @@ use crate::{
 /// Title Element
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Title<'a> {
     /// Headline level, number of stars
     pub level: usize,


### PR DESCRIPTION
Elements provide an into_owned method to give them a static lifetime, so they can be used independently of the indextree (arena). This cannot actually be called by users, however, because it is a consuming method, and there doesn't seem to be any way to get an owning reference to an element*.

This PR addresses the problem by making all public elements which provide into_owned derive Clone. I don't see any obvious reason why they should not be Clone.

Another option would be to change into_owned to to_owned and having it take &self instead of self. I started to write that, but found that it resulted in a lot of duplicated code -- if the structs aren't Clone, to_owned can't call into_owned, and having into_owned call to_owned will result in unnecessary copies (e.g., if some/all struct members are already owned).

I also looked at implementing std::borrow::ToOwned as part of that, but can't seem to figure out how to convince it to change the lifetime to static, and a bit of googling convinced me it may not be possible at present.

* Technically, since all fields are public, a user could use nested {} to construct the structs out of their cloneable parts, but this is fragile and requires a lot of boilerplate.