### PR TITLE
Fix is_commented to look for only a single space.

### DIFF
--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -82,7 +82,7 @@ impl Title<'_> {
 
     /// Returns `true` if this headline is commented
     pub fn is_commented(&self) -> bool {
-        self.raw.starts_with("COMMENT ")
+        self.raw.starts_with("COMMENT ") || self.raw == "COMMENT"
     }
 
     pub fn into_owned(self) -> Title<'static> {

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -82,7 +82,7 @@ impl Title<'_> {
 
     /// Returns `true` if this headline is commented
     pub fn is_commented(&self) -> bool {
-        self.raw.starts_with("COMMENT  ")
+        self.raw.starts_with("COMMENT ")
     }
 
     pub fn into_owned(self) -> Title<'static> {


### PR DESCRIPTION
Two spaces is incorrect, but I also briefly checked whether other whitespace should be allowed. The org spec states:

> If the first word appearing in the title is “COMMENT”, the headline will be considered as “commented”. Case is significant.

But it does not define "word". From trying it out in Emacs, tabs don't work, it must be followed by at least one space.