### PR TITLE
Fix is_commented to recognize any whitespace.

### DIFF
--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -82,7 +82,7 @@ impl Title<'_> {
 
     /// Returns `true` if this headline is commented
     pub fn is_commented(&self) -> bool {
-        self.raw.starts_with("COMMENT ") || self.raw == "COMMENT"
+        self.raw.starts_with("COMMENT") && self.raw.chars().nth(7).unwrap_or(' ').is_whitespace()
     }
 
     pub fn into_owned(self) -> Title<'static> {


### PR DESCRIPTION
I have verified with org-element that it accepts Unicode whitespace as
well, so is_whitespace() is correct, not is_ascii_whitespace(). Note
that org-mode itself does not seem to respect Unicode whitespace, at
least not the font-lock.