### PR TITLE
Provide preserve-property-order feature using IndexMap.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "PoiScript/orgize" }
 [features]
 default = ["ser"]
 ser = ["serde", "serde_indextree"]
+preserve-property-order = ["indexmap"]
 
 [dependencies]
 bytecount = "0.6.0"
@@ -31,6 +32,7 @@ nom = { version = "5.1.1", default-features = false, features = ["std"] }
 serde = { version = "1.0.106", optional = true, features = ["derive"] }
 serde_indextree = { version = "0.2.0", optional = true }
 syntect = { version = "4.1.0", optional = true }
+indexmap = { version = "1.3.2", features = ["serde-1"], optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ travis-ci = { repository = "PoiScript/orgize" }
 
 [features]
 default = ["ser"]
-ser = ["serde", "serde_indextree"]
-preserve-property-order = ["indexmap"]
+ser = ["serde", "serde_indextree", "indexmap/serde-1"]
 
 [dependencies]
 bytecount = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ By now, orgize provides four features:
 
 + `syntect`: provides `SyntectHtmlHandler` for highlighting code block, disabled by default.
 
-+ `preserve-property-order`: Uses `IndexMap` instead of `HashMap` to represent properties, disabled by default.
++ `indexmap`: Uses `IndexMap` instead of `HashMap` for properties to preserve their order, disabled by default.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -195,13 +195,15 @@ println!("{}", to_string(&org).unwrap());
 
 ## Features
 
-By now, orgize provides three features:
+By now, orgize provides four features:
 
 + `ser`: adds the ability to serialize `Org` and other elements using `serde`, enabled by default.
 
 + `chrono`: adds the ability to convert `Datetime` into `chrono` structs, disabled by default.
 
 + `syntect`: provides `SyntectHtmlHandler` for highlighting code block, disabled by default.
+
++ `preserve-property-order`: Uses `IndexMap` instead of `HashMap` to represent properties, disabled by default.
 
 ## License
 

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -1,10 +1,10 @@
 //! Headline Title
 
-#[cfg(not(feature = "preserve-property-order"))]
-type PropertiesMap<K, V> = std::collections::HashMap<K, V>;
+#[cfg(not(feature = "indexmap"))]
+pub type PropertiesMap<K, V> = std::collections::HashMap<K, V>;
 
-#[cfg(feature = "preserve-property-order")]
-type PropertiesMap<K, V> = indexmap::IndexMap<K, V>;
+#[cfg(feature = "indexmap")]
+pub type PropertiesMap<K, V> = indexmap::IndexMap<K, V>;
 
 use std::borrow::Cow;
 
@@ -501,9 +501,9 @@ fn preserve_properties_drawer_order() {
         .into_iter()
         .collect();
 
-    #[cfg(not(feature = "preserve-property-order"))]
+    #[cfg(not(feature = "indexmap"))]
     parsed.sort();
-    #[cfg(not(feature = "preserve-property-order"))]
+    #[cfg(not(feature = "indexmap"))]
     properties.sort();
 
     assert_eq!(parsed, properties);


### PR DESCRIPTION
This adds the feature `preserve-property-order` feature (disabled by default) to use IndexMap instead of HashMap to represent the properties drawer. IndexMap uses order of insertion as iteration order, so that properties will be written out in the same order they were in the org file.

For #12 