### PR TITLE
Implement Display trait for Datetime and Timestamp, and share the code with Org formatting

### DIFF
--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -151,6 +151,27 @@ pub enum Timestamp<'a> {
     },
 }
 
+impl fmt::Display for Timestamp<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Timestamp::Active { start, .. } => {
+                write!(f, "<{}>", start)?;
+            }
+            Timestamp::Inactive { start, .. } => {
+                write!(f, "[{}]", start)?;
+            }
+            Timestamp::ActiveRange { start, end, .. } => {
+                write!(f, "<{}>--<{}>", start, end)?;
+            }
+            Timestamp::InactiveRange { start, end, .. } => {
+                write!(f, "<{}>--<{}>", start, end)?;
+            }
+            Timestamp::Diary { value } => write!(f, "<%%({})>", value)?,
+        }
+        Ok(())
+    }
+}
+
 impl Timestamp<'_> {
     pub(crate) fn parse_active(input: &str) -> Option<(&str, Timestamp)> {
         parse_active(input).ok()

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 
 use nom::{
     bytes::complete::{tag, take, take_till, take_while, take_while_m_n},
@@ -21,6 +22,20 @@ pub struct Datetime<'a> {
     pub hour: Option<u8>,
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
     pub minute: Option<u8>,
+}
+
+impl fmt::Display for Datetime<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02} {}",
+            self.year, self.month, self.day, self.dayname
+        )?;
+        if let (Some(hour), Some(minute)) = (self.hour, self.minute) {
+            write!(f, " {:02}:{:02}", hour, minute)?;
+        }
+        Ok(())
+    }
 }
 
 impl Datetime<'_> {

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -4,7 +4,6 @@ use std::io::{Error, Result as IOResult, Write};
 use jetscii::{bytes, BytesConst};
 
 use crate::elements::{Element, Table, TableCell, TableRow, Timestamp};
-use crate::export::write_datetime;
 
 /// A wrapper for escaping sensitive characters in html.
 ///
@@ -144,18 +143,16 @@ impl HtmlHandler<Error> for DefaultHtmlHandler {
 
                 match timestamp {
                     Timestamp::Active { start, .. } => {
-                        write_datetime(&mut w, "&lt;", start, "&gt;")?;
+                        write!(&mut w, "&lt;{}&gt;", start)?;
                     }
                     Timestamp::Inactive { start, .. } => {
-                        write_datetime(&mut w, "[", start, "]")?;
+                        write!(&mut w, "[{}]", start)?;
                     }
                     Timestamp::ActiveRange { start, end, .. } => {
-                        write_datetime(&mut w, "&lt;", start, "&gt;&#x2013;")?;
-                        write_datetime(&mut w, "&lt;", end, "&gt;")?;
+                        write!(&mut w, "&lt;{}&gt;&#<2013;&lt;{}&gt;", start, end)?;
                     }
                     Timestamp::InactiveRange { start, end, .. } => {
-                        write_datetime(&mut w, "[", start, "]&#x2013;")?;
-                        write_datetime(&mut w, "[", end, "]")?;
+                        write!(&mut w, "&lt;{}&gt;&#<2013;&lt;{}&gt;", start, end)?;
                     }
                     Timestamp::Diary { value } => {
                         write!(&mut w, "&lt;%%({})&gt;", HtmlEscape(value))?

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -7,25 +7,3 @@ mod org;
 pub use html::SyntectHtmlHandler;
 pub use html::{DefaultHtmlHandler, HtmlEscape, HtmlHandler};
 pub use org::{DefaultOrgHandler, OrgHandler};
-
-use std::io::{Error, Write};
-
-use crate::elements::Datetime;
-
-pub(crate) fn write_datetime<W: Write>(
-    mut w: W,
-    start: &str,
-    datetime: &Datetime,
-    end: &str,
-) -> Result<(), Error> {
-    write!(w, "{}", start)?;
-    write!(
-        w,
-        "{}-{:02}-{:02} {}",
-        datetime.year, datetime.month, datetime.day, datetime.dayname
-    )?;
-    if let (Some(hour), Some(minute)) = (datetime.hour, datetime.minute) {
-        write!(w, " {:02}:{:02}", hour, minute)?;
-    }
-    write!(w, "{}", end)
-}

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::io::{Error, Result as IOResult, Write};
 
 use crate::elements::{Clock, Element, Table, Timestamp};
@@ -125,7 +126,7 @@ impl OrgHandler<Error> for DefaultOrgHandler {
             Element::Target(_target) => (),
             Element::Text { value } => write!(w, "{}", value)?,
             Element::Timestamp(timestamp) => {
-                write_timestamp(&mut w, &timestamp)?;
+                write!(&mut w, "{}", timestamp)?;
             }
             Element::Verbatim { value } => write!(w, "={}=", value)?,
             Element::FnDef(fn_def) => {
@@ -245,22 +246,19 @@ impl OrgHandler<Error> for DefaultOrgHandler {
                 writeln!(&mut w)?;
                 if let Some(planning) = &title.planning {
                     if let Some(scheduled) = &planning.scheduled {
-                        write!(&mut w, "SCHEDULED: ")?;
-                        write_timestamp(&mut w, &scheduled)?;
+                        write!(&mut w, "SCHEDULED: {}", &scheduled)?;
                     }
                     if let Some(deadline) = &planning.deadline {
                         if planning.scheduled.is_some() {
                             write!(&mut w, " ")?;
                         }
-                        write!(&mut w, "DEADLINE: ")?;
-                        write_timestamp(&mut w, &deadline)?;
+                        write!(&mut w, "DEADLINE: {}", &deadline)?;
                     }
                     if let Some(closed) = &planning.closed {
                         if planning.deadline.is_some() {
                             write!(&mut w, " ")?;
                         }
-                        write!(&mut w, "CLOSED: ")?;
-                        write_timestamp(&mut w, &closed)?;
+                        write!(&mut w, "CLOSED: {}", &closed)?;
                     }
                     writeln!(&mut w)?;
                 }
@@ -292,25 +290,6 @@ impl OrgHandler<Error> for DefaultOrgHandler {
 fn write_blank_lines<W: Write>(mut w: W, count: usize) -> Result<(), Error> {
     for _ in 0..count {
         writeln!(w)?;
-    }
-    Ok(())
-}
-
-fn write_timestamp<W: Write>(mut w: W, timestamp: &Timestamp) -> Result<(), Error> {
-    match timestamp {
-        Timestamp::Active { start, .. } => {
-            write!(w, "<{}>", start)?;
-        }
-        Timestamp::Inactive { start, .. } => {
-            write!(w, "[{}]", start)?;
-        }
-        Timestamp::ActiveRange { start, end, .. } => {
-            write!(w, "<{}>--<{}>", start, end)?;
-        }
-        Timestamp::InactiveRange { start, end, .. } => {
-            write!(w, "<{}>--<{}>", start, end)?;
-        }
-        Timestamp::Diary { value } => write!(w, "<%%({})>", value)?,
     }
     Ok(())
 }

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,7 +1,6 @@
 use std::io::{Error, Result as IOResult, Write};
 
 use crate::elements::{Clock, Element, Table, Timestamp};
-use crate::export::write_datetime;
 
 pub trait OrgHandler<E: From<Error>>: Default {
     fn start<W: Write>(&mut self, w: W, element: &Element) -> Result<(), E>;
@@ -143,15 +142,13 @@ impl OrgHandler<Error> for DefaultOrgHandler {
                         post_blank,
                         ..
                     } => {
-                        write_datetime(&mut w, "[", &start, "]--")?;
-                        write_datetime(&mut w, "[", &end, "]")?;
-                        writeln!(&mut w, " => {}", duration)?;
+                        writeln!(&mut w, "[{}]--[{}] => {}", &start, &end, duration)?;
                         write_blank_lines(&mut w, *post_blank)?;
                     }
                     Clock::Running {
                         start, post_blank, ..
                     } => {
-                        write_datetime(&mut w, "[", &start, "]\n")?;
+                        write!(&mut w, "[{}]\n", &start)?;
                         write_blank_lines(&mut w, *post_blank)?;
                     }
                 }
@@ -302,18 +299,16 @@ fn write_blank_lines<W: Write>(mut w: W, count: usize) -> Result<(), Error> {
 fn write_timestamp<W: Write>(mut w: W, timestamp: &Timestamp) -> Result<(), Error> {
     match timestamp {
         Timestamp::Active { start, .. } => {
-            write_datetime(w, "<", start, ">")?;
+            write!(w, "<{}>", start)?;
         }
         Timestamp::Inactive { start, .. } => {
-            write_datetime(w, "[", start, "]")?;
+            write!(w, "[{}]", start)?;
         }
         Timestamp::ActiveRange { start, end, .. } => {
-            write_datetime(&mut w, "<", start, ">--")?;
-            write_datetime(&mut w, "<", end, ">")?;
+            write!(w, "<{}>--<{}>", start, end)?;
         }
         Timestamp::InactiveRange { start, end, .. } => {
-            write_datetime(&mut w, "[", start, "]--")?;
-            write_datetime(&mut w, "[", end, "]")?;
+            write!(w, "<{}>--<{}>", start, end)?;
         }
         Timestamp::Diary { value } => write!(w, "<%%({})>", value)?,
     }


### PR DESCRIPTION
It is convenient to implement the Display trait, as then users can use the type in format! and write!, call to_string(), etc. I don't think it's as important for "bigger" elements which are unlikely to be needed by a user except when writing output, but timestamps are the sort of thing that may be needed outside the context of an export.