### PR TITLE
Disable JSON example when built without serde.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@
 //! use serde_json::{json, to_string};
 //!
 //! let org = Org::parse("I 'm *bold*.");
+//! #[cfg(feature = "ser")]
 //! println!("{}", to_string(&org).unwrap());
 //!
 //! // {


### PR DESCRIPTION
Currently, the json example under examples/ and this doctest fail when running test targets without ser. I don't know how to fix the example, but we can at least fix the doctest.