### PR TITLE
Add repeater and delay to timestamp parsing

### DIFF
--- a/src/elements/clock.rs
+++ b/src/elements/clock.rs
@@ -8,7 +8,7 @@ use nom::{
     IResult,
 };
 
-use crate::elements::timestamp::{parse_inactive, Datetime, Timestamp};
+use crate::elements::timestamp::{parse_inactive, Datetime, Delay, Repeater, Timestamp};
 use crate::parse::combinators::{blank_lines_count, eol};
 
 /// Clock Element
@@ -24,9 +24,9 @@ pub enum Clock<'a> {
         /// Time end
         end: Datetime<'a>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        repeater: Option<Cow<'a, str>>,
+        repeater: Option<Repeater>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        delay: Option<Cow<'a, str>>,
+        delay: Option<Delay>,
         /// Clock duration
         duration: Cow<'a, str>,
         /// Numbers of blank lines between the clock line and next non-blank
@@ -38,9 +38,9 @@ pub enum Clock<'a> {
         /// Time start
         start: Datetime<'a>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        repeater: Option<Cow<'a, str>>,
+        repeater: Option<Repeater>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        delay: Option<Cow<'a, str>>,
+        delay: Option<Delay>,
         /// Numbers of blank lines between the clock line and next non-blank
         /// line or buffer's end
         post_blank: usize,
@@ -64,8 +64,8 @@ impl Clock<'_> {
             } => Clock::Closed {
                 start: start.into_owned(),
                 end: end.into_owned(),
-                repeater: repeater.map(Into::into).map(Cow::Owned),
-                delay: delay.map(Into::into).map(Cow::Owned),
+                repeater,
+                delay,
                 duration: duration.into_owned().into(),
                 post_blank,
             },
@@ -76,8 +76,8 @@ impl Clock<'_> {
                 post_blank,
             } => Clock::Running {
                 start: start.into_owned(),
-                repeater: repeater.map(Into::into).map(Cow::Owned),
-                delay: delay.map(Into::into).map(Cow::Owned),
+                repeater,
+                delay,
                 post_blank,
             },
         }
@@ -119,8 +119,8 @@ impl Clock<'_> {
             } => Timestamp::InactiveRange {
                 start: start.clone(),
                 end: end.clone(),
-                repeater: repeater.clone(),
-                delay: delay.clone(),
+                repeater: *repeater,
+                delay: *delay,
             },
             Clock::Running {
                 start,
@@ -129,8 +129,8 @@ impl Clock<'_> {
                 ..
             } => Timestamp::Inactive {
                 start: start.clone(),
-                repeater: repeater.clone(),
-                delay: delay.clone(),
+                repeater: *repeater,
+                delay: *delay,
             },
         }
     }

--- a/src/elements/planning.rs
+++ b/src/elements/planning.rs
@@ -1,6 +1,6 @@
 use memchr::memchr;
 
-use crate::elements::Timestamp;
+use crate::elements::{timestamp::parse_timestamp, Timestamp};
 
 /// Planning element
 #[cfg_attr(test, derive(PartialEq))]
@@ -31,8 +31,7 @@ impl Planning<'_> {
 
             macro_rules! set_timestamp {
                 ($timestamp:expr) => {{
-                    let (new_tail, timestamp) =
-                        Timestamp::parse_active(next).or(Timestamp::parse_inactive(next))?;
+                    let (new_tail, timestamp) = parse_timestamp(next).ok()?;
                     $timestamp = Some(timestamp);
                     tail = new_tail.trim_start();
                 }};

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::fmt::{self, Write};
 
 use nom::{
@@ -9,6 +10,8 @@ use nom::{
     sequence::{delimited, preceded, separated_pair},
     IResult,
 };
+
+use crate::parsers::{helper_for_parse_element, Parse};
 
 /// Datetime Struct
 #[cfg_attr(test, derive(PartialEq))]
@@ -87,6 +90,13 @@ impl fmt::Display for RepeaterMark {
     }
 }
 
+impl TryFrom<&str> for RepeaterMark {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        helper_for_parse_element(parse_repeater_mark(s)).ok_or(())
+    }
+}
+
 impl AsRef<str> for DelayMark {
     fn as_ref(&self) -> &str {
         match self {
@@ -99,6 +109,13 @@ impl AsRef<str> for DelayMark {
 impl fmt::Display for DelayMark {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_ref())
+    }
+}
+
+impl TryFrom<&str> for DelayMark {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        helper_for_parse_element(parse_delay_mark(s)).ok_or(())
     }
 }
 
@@ -126,15 +143,36 @@ impl fmt::Display for TimeUnit {
     }
 }
 
+impl TryFrom<&str> for TimeUnit {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        helper_for_parse_element(parse_time_unit(s)).ok_or(())
+    }
+}
+
 impl fmt::Display for Repeater {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}{}{}", self.mark, self.value, self.unit)
     }
 }
 
+impl TryFrom<&str> for Repeater {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        helper_for_parse_element(parse_repeater(s)).ok_or(())
+    }
+}
+
 impl fmt::Display for Delay {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}{}{}", self.mark, self.value, self.unit)
+    }
+}
+
+impl TryFrom<&str> for Delay {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        helper_for_parse_element(parse_delay(s)).ok_or(())
     }
 }
 
@@ -149,6 +187,12 @@ impl fmt::Display for Datetime<'_> {
             write!(f, " {:02}:{:02}", hour, minute)?;
         }
         Ok(())
+    }
+}
+
+impl<'a> Parse<'a> for Datetime<'a> {
+    fn parse(s: &'a str) -> Option<Datetime<'a>> {
+        helper_for_parse_element(parse_datetime(s))
     }
 }
 
@@ -349,6 +393,12 @@ impl Timestamp<'_> {
                 value: value.into_owned().into(),
             },
         }
+    }
+}
+
+impl<'a> Parse<'a> for Timestamp<'a> {
+    fn parse(s: &'a str) -> Option<Timestamp<'a>> {
+        helper_for_parse_element(parse_timestamp(s))
     }
 }
 

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -2,10 +2,11 @@ use std::borrow::Cow;
 use std::fmt::{self, Write};
 
 use nom::{
-    bytes::complete::{tag, take, take_till, take_while, take_while_m_n},
-    character::complete::{space0, space1},
-    combinator::{map, map_res, opt},
-    sequence::preceded,
+    branch::{alt, permutation},
+    bytes::complete::{tag, take, take_until, take_while1, take_while_m_n},
+    character::complete::{digit1, one_of, space0, space1},
+    combinator::{map, map_res, opt, verify},
+    sequence::{delimited, preceded, separated_pair},
     IResult,
 };
 
@@ -142,7 +143,7 @@ impl fmt::Display for Datetime<'_> {
         write!(
             f,
             "{:04}-{:02}-{:02} {}",
-            self.year, self.month, self.day, self.dayname
+            self.year, self.month, self.day, self.dayname,
         )?;
         if let (Some(hour), Some(minute)) = (self.hour, self.minute) {
             write!(f, " {:02}:{:02}", hour, minute)?;
@@ -247,17 +248,25 @@ pub enum Timestamp<'a> {
         start: Datetime<'a>,
         end: Datetime<'a>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        repeater: Option<Repeater>,
+        start_repeater: Option<Repeater>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        delay: Option<Delay>,
+        end_repeater: Option<Repeater>,
+        #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
+        start_delay: Option<Delay>,
+        #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
+        end_delay: Option<Delay>,
     },
     InactiveRange {
         start: Datetime<'a>,
         end: Datetime<'a>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        repeater: Option<Repeater>,
+        start_repeater: Option<Repeater>,
         #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
-        delay: Option<Delay>,
+        end_repeater: Option<Repeater>,
+        #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
+        start_delay: Option<Delay>,
+        #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
+        end_delay: Option<Delay>,
     },
     Diary {
         value: Cow<'a, str>,
@@ -286,18 +295,6 @@ impl fmt::Display for Timestamp<'_> {
 }
 
 impl Timestamp<'_> {
-    pub(crate) fn parse_active(input: &str) -> Option<(&str, Timestamp)> {
-        parse_active(input).ok()
-    }
-
-    pub(crate) fn parse_inactive(input: &str) -> Option<(&str, Timestamp)> {
-        parse_inactive(input).ok()
-    }
-
-    pub(crate) fn parse_diary(input: &str) -> Option<(&str, Timestamp)> {
-        parse_diary(input).ok()
-    }
-
     pub fn into_owned(self) -> Timestamp<'static> {
         match self {
             Timestamp::Active {
@@ -321,150 +318,38 @@ impl Timestamp<'_> {
             Timestamp::ActiveRange {
                 start,
                 end,
-                repeater,
-                delay,
+                start_repeater,
+                end_repeater,
+                start_delay,
+                end_delay,
             } => Timestamp::ActiveRange {
                 start: start.into_owned(),
                 end: end.into_owned(),
-                repeater,
-                delay,
+                start_repeater,
+                end_repeater,
+                start_delay,
+                end_delay,
             },
             Timestamp::InactiveRange {
                 start,
                 end,
-                repeater,
-                delay,
+                start_repeater,
+                end_repeater,
+                start_delay,
+                end_delay,
             } => Timestamp::InactiveRange {
                 start: start.into_owned(),
                 end: end.into_owned(),
-                repeater,
-                delay,
+                start_repeater,
+                end_repeater,
+                start_delay,
+                end_delay,
             },
             Timestamp::Diary { value } => Timestamp::Diary {
                 value: value.into_owned().into(),
             },
         }
     }
-}
-
-pub fn parse_active(input: &str) -> IResult<&str, Timestamp, ()> {
-    let (input, _) = tag("<")(input)?;
-    let (input, start) = parse_datetime(input)?;
-
-    if input.starts_with('-') {
-        let (input, (hour, minute)) = parse_time(&input[1..])?;
-        let (input, _) = space0(input)?;
-
-        // TODO: delay-or-repeater
-        let (input, _) = tag(">")(input)?;
-        let mut end = start.clone();
-        end.hour = Some(hour);
-        end.minute = Some(minute);
-        return Ok((
-            input,
-            Timestamp::ActiveRange {
-                start,
-                end,
-                repeater: None,
-                delay: None,
-            },
-        ));
-    }
-
-    let (input, _) = space0(input)?;
-    // TODO: delay-or-repeater
-    let (input, _) = tag(">")(input)?;
-
-    if input.starts_with("--<") {
-        let (input, end) = parse_datetime(&input["--<".len()..])?;
-        let (input, _) = space0(input)?;
-        // TODO: delay-or-repeater
-        let (input, _) = tag(">")(input)?;
-        Ok((
-            input,
-            Timestamp::ActiveRange {
-                start,
-                end,
-                repeater: None,
-                delay: None,
-            },
-        ))
-    } else {
-        Ok((
-            input,
-            Timestamp::Active {
-                start,
-                repeater: None,
-                delay: None,
-            },
-        ))
-    }
-}
-
-pub fn parse_inactive(input: &str) -> IResult<&str, Timestamp, ()> {
-    let (input, _) = tag("[")(input)?;
-    let (input, start) = parse_datetime(input)?;
-
-    if input.starts_with('-') {
-        let (input, (hour, minute)) = parse_time(&input[1..])?;
-        let (input, _) = space0(input)?;
-        // TODO: delay-or-repeater
-        let (input, _) = tag("]")(input)?;
-        let mut end = start.clone();
-        end.hour = Some(hour);
-        end.minute = Some(minute);
-        return Ok((
-            input,
-            Timestamp::InactiveRange {
-                start,
-                end,
-                repeater: None,
-                delay: None,
-            },
-        ));
-    }
-
-    let (input, _) = space0(input)?;
-    // TODO: delay-or-repeater
-    let (input, _) = tag("]")(input)?;
-
-    if input.starts_with("--[") {
-        let (input, end) = parse_datetime(&input["--[".len()..])?;
-        let (input, _) = space0(input)?;
-        // TODO: delay-or-repeater
-        let (input, _) = tag("]")(input)?;
-        Ok((
-            input,
-            Timestamp::InactiveRange {
-                start,
-                end,
-                repeater: None,
-                delay: None,
-            },
-        ))
-    } else {
-        Ok((
-            input,
-            Timestamp::Inactive {
-                start,
-                repeater: None,
-                delay: None,
-            },
-        ))
-    }
-}
-
-pub fn parse_diary(input: &str) -> IResult<&str, Timestamp, ()> {
-    let (input, _) = tag("<%%(")(input)?;
-    let (input, value) = take_till(|c| c == ')' || c == '>' || c == '\n')(input)?;
-    let (input, _) = tag(")>")(input)?;
-
-    Ok((
-        input,
-        Timestamp::Diary {
-            value: value.into(),
-        },
-    ))
 }
 
 fn parse_time(input: &str) -> IResult<&str, (u8, u8), ()> {
@@ -476,44 +361,232 @@ fn parse_time(input: &str) -> IResult<&str, (u8, u8), ()> {
     Ok((input, (hour, minute)))
 }
 
-fn parse_datetime(input: &str) -> IResult<&str, Datetime, ()> {
+fn parse_repeater_mark(input: &str) -> IResult<&str, RepeaterMark, ()> {
+    let (input, mark) = alt((tag("++"), tag("+"), tag(".+")))(input)?;
+    Ok((
+        input,
+        match mark {
+            "++" => RepeaterMark::CatchUp,
+            "+" => RepeaterMark::Cumulate,
+            ".+" => RepeaterMark::Restart,
+            _ => unreachable!(),
+        },
+    ))
+}
+
+fn parse_delay_mark(input: &str) -> IResult<&str, DelayMark, ()> {
+    let (input, mark) = alt((tag("--"), tag("-")))(input)?;
+    Ok((
+        input,
+        match mark {
+            "--" => DelayMark::First,
+            "-" => DelayMark::All,
+            _ => unreachable!(),
+        },
+    ))
+}
+
+fn parse_time_unit(input: &str) -> IResult<&str, TimeUnit, ()> {
+    let (input, unit) = one_of("hdwmy")(input)?;
+    Ok((
+        input,
+        match unit {
+            'h' => TimeUnit::Hour,
+            'd' => TimeUnit::Day,
+            'w' => TimeUnit::Week,
+            'm' => TimeUnit::Month,
+            'y' => TimeUnit::Year,
+            _ => unreachable!(),
+        },
+    ))
+}
+
+fn parse_interval(input: &str) -> IResult<&str, (usize, TimeUnit), ()> {
+    let (input, value) = map_res(digit1, |num| usize::from_str_radix(num, 10))(input)?;
+    let (input, unit) = parse_time_unit(input)?;
+    Ok((input, (value, unit)))
+}
+
+fn parse_repeater(input: &str) -> IResult<&str, Repeater, ()> {
+    let (input, mark) = parse_repeater_mark(input)?;
+    let (input, (value, unit)) = parse_interval(input)?;
+    Ok((input, Repeater { mark, value, unit }))
+}
+
+fn parse_delay(input: &str) -> IResult<&str, Delay, ()> {
+    let (input, mark) = parse_delay_mark(input)?;
+    let (input, (value, unit)) = parse_interval(input)?;
+    Ok((input, Delay { mark, value, unit }))
+}
+
+fn parse_repeater_and_delay(input: &str) -> IResult<&str, (Option<Repeater>, Option<Delay>), ()> {
+    let (input, (repeater1, delay, repeater2)) = permutation((
+        opt(preceded(space1, parse_repeater)),
+        opt(preceded(space1, parse_delay)),
+        opt(preceded(space1, parse_repeater)),
+    ))(input)?;
+    Ok((input, (repeater1.or(repeater2), delay)))
+}
+
+fn parse_dayname(input: &str) -> IResult<&str, &str, ()> {
+    let (input, dayname) = verify(
+        take_while1(|c: char| !c.is_whitespace() && c != '>' && c != ']'),
+        |dayname: &str| {
+            !dayname
+                .chars()
+                .any(|c| c.is_ascii_digit() || c == '+' || c == '-')
+        },
+    )(input)?;
+    Ok((input, dayname))
+}
+
+fn parse_datetime<'a>(input: &'a str) -> IResult<&str, Datetime<'a>, ()> {
     let parse_u8 = |num| u8::from_str_radix(num, 10);
 
     let (input, year) = map_res(take(4usize), |num| u16::from_str_radix(num, 10))(input)?;
     let (input, _) = tag("-")(input)?;
-    let (input, month) = map_res(take(2usize), parse_u8)(input)?;
+    let (input, month) =
+        map_res(take_while_m_n(1, 2, |c: char| c.is_ascii_digit()), parse_u8)(input)?;
     let (input, _) = tag("-")(input)?;
-    let (input, day) = map_res(take(2usize), parse_u8)(input)?;
-    let (input, _) = space1(input)?;
-    let (input, dayname) = take_while(|c: char| {
-        !c.is_ascii_whitespace()
-            && !c.is_ascii_digit()
-            && c != '+'
-            && c != '-'
-            && c != ']'
-            && c != '>'
-    })(input)?;
+    let (input, day) =
+        map_res(take_while_m_n(1, 2, |c: char| c.is_ascii_digit()), parse_u8)(input)?;
+    let (input, dayname) = opt(preceded(space1, parse_dayname))(input)?;
     let (input, (hour, minute)) = map(opt(preceded(space1, parse_time)), |time| {
         (time.map(|t| t.0), time.map(|t| t.1))
     })(input)?;
-
     Ok((
         input,
         Datetime {
             year,
             month,
             day,
-            dayname: dayname.into(),
+            dayname: dayname.unwrap_or_default().into(),
             hour,
             minute,
         },
     ))
 }
 
+#[cfg_attr(test, derive(PartialEq, Debug, Clone))]
+struct TimestampParts<'a> {
+    datetime: Datetime<'a>,
+    end_time: Option<(u8, u8)>,
+    repeater: Option<Repeater>,
+    delay: Option<Delay>,
+}
+
+fn parse_timestamp_parts(input: &str) -> IResult<&str, TimestampParts, ()> {
+    let (input, datetime) = parse_datetime(input)?;
+    let (input, end_time) = opt(preceded(tag("-"), parse_time))(input)?;
+    let (input, (repeater, delay)) = parse_repeater_and_delay(input)?;
+
+    // Org timestamps allow terminal space before the > or ].
+    let (input, _) = space0(input)?;
+    Ok((
+        input,
+        TimestampParts {
+            datetime,
+            end_time,
+            repeater,
+            delay,
+        },
+    ))
+}
+
+pub(crate) fn parse_timestamp<'a>(input: &'a str) -> IResult<&str, Timestamp<'a>, ()> {
+    alt((
+        map(
+            delimited(
+                tag("<"),
+                separated_pair(parse_timestamp_parts, tag(">--<"), parse_timestamp_parts),
+                tag(">"),
+            ),
+            |(start, end)| Timestamp::ActiveRange {
+                start: start.datetime,
+                end: end.datetime,
+                start_delay: start.delay,
+                start_repeater: start.repeater,
+                end_delay: end.delay,
+                end_repeater: end.repeater,
+            },
+        ),
+        map(
+            delimited(
+                tag("["),
+                separated_pair(parse_timestamp_parts, tag("]--["), parse_timestamp_parts),
+                tag("]"),
+            ),
+            |(start, end)| Timestamp::InactiveRange {
+                start: start.datetime,
+                end: end.datetime,
+                start_delay: start.delay,
+                start_repeater: start.repeater,
+                end_delay: end.delay,
+                end_repeater: end.repeater,
+            },
+        ),
+        map(
+            delimited(tag("<"), parse_timestamp_parts, tag(">")),
+            |parts| match parts.end_time {
+                Some((hour, minute)) => {
+                    let mut end = parts.datetime.clone();
+                    end.hour = Some(hour);
+                    end.minute = Some(minute);
+                    Timestamp::ActiveRange {
+                        start: parts.datetime,
+                        end,
+                        start_repeater: parts.repeater,
+                        end_repeater: parts.repeater,
+                        start_delay: parts.delay,
+                        end_delay: parts.delay,
+                    }
+                }
+                None => Timestamp::Active {
+                    start: parts.datetime,
+                    delay: parts.delay,
+                    repeater: parts.repeater,
+                },
+            },
+        ),
+        map(
+            delimited(tag("["), parse_timestamp_parts, tag("]")),
+            |parts| Timestamp::Inactive {
+                start: parts.datetime,
+                delay: parts.delay,
+                repeater: parts.repeater,
+            },
+        ),
+        map(
+            delimited(tag("<%%("), take_until(")>"), tag(")>")),
+            |diary: &str| Timestamp::Diary {
+                value: diary.into(),
+            },
+        ),
+    ))(input)
+}
+
 #[test]
 fn parse() {
     assert_eq!(
-        parse_inactive("[2003-09-16 Tue]"),
+        parse_timestamp("<2019-03-26 Fri 03:33>"),
+        Ok((
+            "",
+            Timestamp::Active {
+                start: Datetime {
+                    year: 2019,
+                    month: 3,
+                    day: 26,
+                    dayname: "Fri".into(),
+                    hour: Some(3),
+                    minute: Some(33),
+                },
+                repeater: None,
+                delay: None,
+            },
+        ))
+    );
+    assert_eq!(
+        parse_timestamp("[2003-09-16 Tue]"),
         Ok((
             "",
             Timestamp::Inactive {
@@ -531,7 +604,7 @@ fn parse() {
         ))
     );
     assert_eq!(
-        parse_inactive("[2003-09-16 Tue 09:39]--[2003-09-16 Tue 10:39]"),
+        parse_timestamp("[2003-09-16 Tue 09:39]--[2003-09-16 Tue 10:39]"),
         Ok((
             "",
             Timestamp::InactiveRange {
@@ -551,13 +624,145 @@ fn parse() {
                     hour: Some(10),
                     minute: Some(39),
                 },
-                repeater: None,
-                delay: None
+                start_repeater: None,
+                end_repeater: None,
+                start_delay: None,
+                end_delay: None,
+            },
+        ))
+    );
+
+    // For consistency with org-element, when there are two end times specified
+    // like this, we take the first time in each timestamp as the start/end
+    // respectively. These are all invalid per the org spec, but org-element
+    // handles them, and they seem like an case that could easily come up in
+    // normal use.
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Fri 03:14>--<2003-09-19 Mon 04:16-5:29>"),
+        Ok((
+            "",
+            Timestamp::ActiveRange {
+                start: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Fri".into(),
+                    hour: Some(3),
+                    minute: Some(14),
+                },
+                end: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 19,
+                    dayname: "Mon".into(),
+                    hour: Some(4),
+                    minute: Some(16),
+                },
+                start_repeater: None,
+                end_repeater: None,
+                start_delay: None,
+                end_delay: None,
             },
         ))
     );
     assert_eq!(
-        parse_active("<2003-09-16 Tue 09:39-10:39>"),
+        parse_timestamp("<2003-09-16 Fri 02:59-03:14>--<2003-09-16 Mon 5:29>"),
+        Ok((
+            "",
+            Timestamp::ActiveRange {
+                start: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Fri".into(),
+                    hour: Some(2),
+                    minute: Some(59),
+                },
+                end: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Mon".into(),
+                    hour: Some(5),
+                    minute: Some(29),
+                },
+                start_repeater: None,
+                end_repeater: None,
+                start_delay: None,
+                end_delay: None,
+            },
+        ))
+    );
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Fri 02:59-03:14>--<2003-09-16 Mon 04:16-5:29>"),
+        Ok((
+            "",
+            Timestamp::ActiveRange {
+                start: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Fri".into(),
+                    hour: Some(2),
+                    minute: Some(59),
+                },
+                end: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Mon".into(),
+                    hour: Some(4),
+                    minute: Some(16),
+                },
+                start_repeater: None,
+                end_repeater: None,
+                start_delay: None,
+                end_delay: None,
+            },
+        ))
+    );
+
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Fri>--<2003-09-19 Mon>"),
+        Ok((
+            "",
+            Timestamp::ActiveRange {
+                start: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Fri".into(),
+                    hour: None,
+                    minute: None,
+                },
+                end: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 19,
+                    dayname: "Mon".into(),
+                    hour: None,
+                    minute: None,
+                },
+                start_repeater: None,
+                end_repeater: None,
+                start_delay: None,
+                end_delay: None,
+            },
+        ))
+    );
+
+    let repeater = Some(Repeater {
+        mark: RepeaterMark::Cumulate,
+        value: 1,
+        unit: TimeUnit::Week,
+    });
+    let delay = Some(Delay {
+        mark: DelayMark::First,
+        value: 2,
+        unit: TimeUnit::Day,
+    });
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Tue 09:39-10:39 +1w --2d>"),
         Ok((
             "",
             Timestamp::ActiveRange {
@@ -577,9 +782,342 @@ fn parse() {
                     hour: Some(10),
                     minute: Some(39),
                 },
-                repeater: None,
-                delay: None
+                start_repeater: repeater,
+                end_repeater: repeater,
+                start_delay: delay,
+                end_delay: delay,
             },
         ))
+    );
+
+    let repeater2 = Some(Repeater {
+        mark: RepeaterMark::Restart,
+        value: 1,
+        unit: TimeUnit::Year,
+    });
+    let delay2 = Some(Delay {
+        mark: DelayMark::All,
+        value: 3,
+        unit: TimeUnit::Hour,
+    });
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Tue 09:39 +1w --2d>--<2003-09-19 .+1y -3h>"),
+        Ok((
+            "",
+            Timestamp::ActiveRange {
+                start: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 16,
+                    dayname: "Tue".into(),
+                    hour: Some(9),
+                    minute: Some(39),
+                },
+                end: Datetime {
+                    year: 2003,
+                    month: 9,
+                    day: 19,
+                    dayname: Cow::default(),
+                    hour: None,
+                    minute: None,
+                },
+                start_repeater: repeater,
+                end_repeater: repeater2,
+                start_delay: delay,
+                end_delay: delay2,
+            },
+        ))
+    );
+
+    assert_eq!(
+        parse_timestamp("<%%(diary-date 2020 5 2)>"),
+        Ok((
+            "",
+            Timestamp::Diary {
+                value: "diary-date 2020 5 2".into()
+            },
+        ))
+    );
+}
+
+#[test]
+fn test_parse_datetime() {
+    let mut datetime = Datetime {
+        year: 2020,
+        month: 3,
+        day: 1,
+        dayname: Cow::default(),
+        hour: None,
+        minute: None,
+    };
+
+    assert_eq!(parse_datetime("2020-03-01"), Ok(("", datetime.clone())));
+
+    datetime.dayname = "Sun".into();
+    assert_eq!(parse_datetime("2020-03-01 Sun"), Ok(("", datetime.clone())));
+
+    datetime.dayname = "Zeepsday".into();
+    assert_eq!(
+        parse_datetime("2020-3-01 Zeepsday"),
+        Ok(("", datetime.clone()))
+    );
+
+    datetime.dayname = "Sun".into();
+    datetime.month = 7;
+    assert_eq!(parse_datetime("2020-07-1 Sun"), Ok(("", datetime.clone())));
+
+    datetime.dayname = "FRI".into();
+    datetime.month = 1;
+    assert_eq!(parse_datetime("2020-1-1 FRI"), Ok(("", datetime.clone())));
+
+    datetime.dayname = Cow::default();
+    datetime.month = 1;
+    assert_eq!(parse_datetime("2020-1-1 "), Ok((" ", datetime.clone())));
+
+    datetime.year = 0;
+    assert_eq!(parse_datetime("0000-1-1"), Ok(("", datetime.clone())));
+
+    datetime.year = 5;
+    assert_eq!(parse_datetime("0005-1-1"), Ok(("", datetime.clone())));
+
+    datetime.year = 9999;
+    assert_eq!(parse_datetime("9999-1-1"), Ok(("", datetime.clone())));
+
+    assert_eq!(parse_datetime("2-1-1 .+1d/2d").ok(), None,);
+
+    assert_eq!(parse_datetime("-1-1").ok(), None,);
+    assert_eq!(parse_datetime("1-1").ok(), None,);
+    assert_eq!(parse_datetime("1").ok(), None,);
+    assert_eq!(parse_datetime("").ok(), None,);
+}
+
+#[test]
+fn test_parse_time() {
+    assert_eq!(parse_time("").ok(), None);
+    assert_eq!(parse_time(":").ok(), None);
+    assert_eq!(parse_time("9").ok(), None);
+    assert_eq!(parse_time("9-9").ok(), None);
+    assert_eq!(parse_time("00:09-00:10"), Ok(("-00:10", (0, 9))));
+
+    assert_eq!(parse_time("5:5").ok(), None);
+    assert_eq!(parse_time(":5").ok(), None);
+    assert_eq!(parse_time(":05").ok(), None);
+
+    assert_eq!(parse_time(" 5:05").ok(), None);
+    assert_eq!(parse_time("5:05"), Ok(("", (5, 5))));
+    assert_eq!(parse_time("05:05"), Ok(("", (5, 5))));
+    assert_eq!(parse_time("00:05\tbees"), Ok(("\tbees", (0, 5))));
+    assert_eq!(parse_time("00:00"), Ok(("", (0, 0))));
+    assert_eq!(parse_time("0:00"), Ok(("", (0, 0))));
+    assert_eq!(parse_time("0:01"), Ok(("", (0, 1))));
+}
+
+#[test]
+fn test_parse_interval() {
+    assert_eq!(parse_interval("5d"), Ok(("", (5, TimeUnit::Day))));
+    assert_eq!(parse_interval("0h"), Ok(("", (0, TimeUnit::Hour))));
+    assert_eq!(parse_interval("1h"), Ok(("", (1, TimeUnit::Hour))));
+    assert_eq!(parse_interval("2m"), Ok(("", (2, TimeUnit::Month))));
+    assert_eq!(
+        parse_interval("02m hello\nworld"),
+        Ok((" hello\nworld", (2, TimeUnit::Month)))
+    );
+    assert_eq!(parse_interval("222y"), Ok(("", (222, TimeUnit::Year))));
+    assert_eq!(parse_interval("").ok(), None);
+    assert_eq!(parse_interval("5").ok(), None);
+    assert_eq!(parse_interval("y").ok(), None);
+    assert_eq!(parse_interval("y5").ok(), None);
+}
+
+#[test]
+fn test_parse_repeater_and_delay() {
+    // Note that parse_repeater_and_delay needs a leading space if non-empty,
+    // due to where it sits in parsing timestamps.
+    for nope in &[
+        " ", "+1d", "--1w", " -1", " 1", " +", " ++", " .+", " -", " --", " +1", " ++1", " .+",
+        " -1", " --1", " 1d", " 5w", " y",
+    ] {
+        assert_eq!(parse_repeater_and_delay(*nope), Ok((*nope, (None, None))));
+    }
+
+    let mut repeater = Repeater {
+        mark: RepeaterMark::Cumulate,
+        unit: TimeUnit::Day,
+        value: 1,
+    };
+    assert_eq!(
+        parse_repeater_and_delay(" +1d"),
+        Ok(("", (Some(repeater), None)))
+    );
+
+    repeater.mark = RepeaterMark::Restart;
+    assert_eq!(
+        parse_repeater_and_delay(" .+1d"),
+        Ok(("", (Some(repeater), None)))
+    );
+
+    repeater.mark = RepeaterMark::CatchUp;
+    assert_eq!(
+        parse_repeater_and_delay(" ++1d"),
+        Ok(("", (Some(repeater), None)))
+    );
+
+    let mut delay = Delay {
+        mark: DelayMark::First,
+        unit: TimeUnit::Year,
+        value: 7,
+    };
+    assert_eq!(
+        parse_repeater_and_delay(" --7y"),
+        Ok(("", (None, Some(delay))))
+    );
+
+    delay.mark = DelayMark::All;
+    assert_eq!(
+        parse_repeater_and_delay(" -7y"),
+        Ok(("", (None, Some(delay))))
+    );
+
+    delay.unit = TimeUnit::Hour;
+    assert_eq!(
+        parse_repeater_and_delay(" -7h"),
+        Ok(("", (None, Some(delay))))
+    );
+
+    delay.unit = TimeUnit::Month;
+    assert_eq!(
+        parse_repeater_and_delay(" -7m"),
+        Ok(("", (None, Some(delay))))
+    );
+
+    delay.unit = TimeUnit::Week;
+    assert_eq!(
+        parse_repeater_and_delay(" -7w"),
+        Ok(("", (None, Some(delay))))
+    );
+    assert_eq!(
+        parse_repeater_and_delay(" -07w"),
+        Ok(("", (None, Some(delay))))
+    );
+
+    assert_eq!(
+        parse_repeater_and_delay(" -7w ++1d"),
+        Ok(("", (Some(repeater), Some(delay))))
+    );
+    assert_eq!(
+        parse_repeater_and_delay(" ++1d -7w"),
+        Ok(("", (Some(repeater), Some(delay))))
+    );
+}
+
+#[test]
+fn test_parse_timestamp_parts() {
+    let mut parts = TimestampParts {
+        datetime: Datetime {
+            year: 2020,
+            month: 1,
+            day: 1,
+            dayname: "".into(),
+            hour: None,
+            minute: None,
+        },
+        end_time: None,
+        repeater: None,
+        delay: None,
+    };
+
+    assert_eq!(parse_timestamp_parts("2020-01-01"), Ok(("", parts.clone())));
+    parts.datetime.hour = Some(1);
+    parts.datetime.minute = Some(0);
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 01:00"),
+        Ok(("", parts.clone()))
+    );
+    parts.end_time = Some((2, 0));
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 01:00-02:00"),
+        Ok(("", parts.clone()))
+    );
+    parts.end_time = None;
+    parts.datetime.hour = None;
+    parts.datetime.minute = None;
+    parts.datetime.dayname = "Fri".into();
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri"),
+        Ok(("", parts.clone()))
+    );
+    parts.datetime.hour = Some(1);
+    parts.datetime.minute = Some(0);
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri 01:00"),
+        Ok(("", parts.clone()))
+    );
+    parts.end_time = Some((2, 0));
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri 01:00-02:00"),
+        Ok(("", parts.clone()))
+    );
+    parts.delay = Some(Delay {
+        mark: DelayMark::All,
+        value: 3,
+        unit: TimeUnit::Day,
+    });
+    parts.datetime.dayname = "".into();
+    parts.datetime.hour = None;
+    parts.datetime.minute = None;
+    parts.end_time = None;
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.datetime.hour = Some(1);
+    parts.datetime.minute = Some(0);
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 01:00 -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.end_time = Some((2, 0));
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 01:00-02:00 -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.datetime.dayname = "Fri".into();
+    parts.datetime.hour = None;
+    parts.datetime.minute = None;
+    parts.end_time = None;
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.datetime.hour = Some(1);
+    parts.datetime.minute = Some(0);
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri 01:00 -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.end_time = Some((2, 0));
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri 01:00-02:00 -3d"),
+        Ok(("", parts.clone()))
+    );
+    parts.datetime.hour = None;
+    parts.datetime.minute = None;
+    parts.end_time = None;
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Fri -3d"),
+        Ok(("", parts.clone()))
+    );
+
+    parts.repeater = Some(Repeater {
+        mark: RepeaterMark::CatchUp,
+        value: 2,
+        unit: TimeUnit::Week,
+    });
+    parts.datetime.dayname = "Mon".into();
+    parts.datetime.hour = Some(3);
+    parts.datetime.minute = Some(14);
+    assert_eq!(
+        parse_timestamp_parts("2020-01-01 Mon 03:14 ++2w -3d hello"),
+        Ok(("hello", parts.clone()))
     );
 }

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -728,24 +728,29 @@ pub(crate) fn parse_timestamp<'a>(input: &'a str) -> IResult<&str, Timestamp<'a>
 
 #[test]
 fn parse() {
+    let timestamp = Timestamp::Active {
+        start: Datetime {
+            year: 2019,
+            month: 3,
+            day: 26,
+            dayname: "Fri".into(),
+            hour: Some(3),
+            minute: Some(33),
+        },
+        repeater: None,
+        delay: None,
+    };
     assert_eq!(
         parse_timestamp("<2019-03-26 Fri 03:33>"),
-        Ok((
-            "",
-            Timestamp::Active {
-                start: Datetime {
-                    year: 2019,
-                    month: 3,
-                    day: 26,
-                    dayname: "Fri".into(),
-                    hour: Some(3),
-                    minute: Some(33),
-                },
-                repeater: None,
-                delay: None,
-            },
-        ))
+        Ok(("", timestamp.clone()))
     );
+    assert_eq!(
+        parse_timestamp("<2019-03-26  Fri   03:33   >"),
+        Ok(("", timestamp))
+    );
+    // Org can't recognize leading space after the <.
+    assert_eq!(parse_timestamp("< 2019-03-26  Fri   03:33   >").ok(), None,);
+
     assert_eq!(
         parse_timestamp("[2003-09-16 Tue]"),
         Ok((
@@ -922,33 +927,35 @@ fn parse() {
         value: 2,
         unit: TimeUnit::Day,
     });
+    let timestamp = Timestamp::ActiveRange {
+        start: Datetime {
+            year: 2003,
+            month: 9,
+            day: 16,
+            dayname: "Tue".into(),
+            hour: Some(9),
+            minute: Some(39),
+        },
+        end: Datetime {
+            year: 2003,
+            month: 9,
+            day: 16,
+            dayname: "Tue".into(),
+            hour: Some(10),
+            minute: Some(39),
+        },
+        start_repeater: repeater,
+        end_repeater: repeater,
+        start_delay: delay,
+        end_delay: delay,
+    };
     assert_eq!(
         parse_timestamp("<2003-09-16 Tue 09:39-10:39 +1w --2d>"),
-        Ok((
-            "",
-            Timestamp::ActiveRange {
-                start: Datetime {
-                    year: 2003,
-                    month: 9,
-                    day: 16,
-                    dayname: "Tue".into(),
-                    hour: Some(9),
-                    minute: Some(39),
-                },
-                end: Datetime {
-                    year: 2003,
-                    month: 9,
-                    day: 16,
-                    dayname: "Tue".into(),
-                    hour: Some(10),
-                    minute: Some(39),
-                },
-                start_repeater: repeater,
-                end_repeater: repeater,
-                start_delay: delay,
-                end_delay: delay,
-            },
-        ))
+        Ok(("", timestamp.clone()))
+    );
+    assert_eq!(
+        parse_timestamp("<2003-09-16 Tue 09:39-10:39 --2d +1w>"),
+        Ok(("", timestamp.clone()))
     );
 
     let repeater2 = Some(Repeater {

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -5,8 +5,8 @@ use std::fmt::{self, Write};
 use nom::{
     branch::{alt, permutation},
     bytes::complete::{tag, take, take_until, take_while1, take_while_m_n},
-    character::complete::{digit1, one_of, space0, space1},
-    combinator::{map, map_res, opt, verify},
+    character::complete::{char, digit1, space0, space1},
+    combinator::{map, map_res, opt, value, verify},
     sequence::{delimited, preceded, separated_pair},
     IResult,
 };
@@ -506,43 +506,28 @@ fn parse_time(input: &str) -> IResult<&str, (u8, u8), ()> {
 }
 
 fn parse_repeater_mark(input: &str) -> IResult<&str, RepeaterMark, ()> {
-    let (input, mark) = alt((tag("++"), tag("+"), tag(".+")))(input)?;
-    Ok((
-        input,
-        match mark {
-            "++" => RepeaterMark::CatchUp,
-            "+" => RepeaterMark::Cumulate,
-            ".+" => RepeaterMark::Restart,
-            _ => unreachable!(),
-        },
-    ))
+    alt((
+        value(RepeaterMark::CatchUp, tag("++")),
+        value(RepeaterMark::Cumulate, tag("+")),
+        value(RepeaterMark::Restart, tag(".+")),
+    ))(input)
 }
 
 fn parse_delay_mark(input: &str) -> IResult<&str, DelayMark, ()> {
-    let (input, mark) = alt((tag("--"), tag("-")))(input)?;
-    Ok((
-        input,
-        match mark {
-            "--" => DelayMark::First,
-            "-" => DelayMark::All,
-            _ => unreachable!(),
-        },
-    ))
+    alt((
+        value(DelayMark::First, tag("--")),
+        value(DelayMark::All, tag("-")),
+    ))(input)
 }
 
 fn parse_time_unit(input: &str) -> IResult<&str, TimeUnit, ()> {
-    let (input, unit) = one_of("hdwmy")(input)?;
-    Ok((
-        input,
-        match unit {
-            'h' => TimeUnit::Hour,
-            'd' => TimeUnit::Day,
-            'w' => TimeUnit::Week,
-            'm' => TimeUnit::Month,
-            'y' => TimeUnit::Year,
-            _ => unreachable!(),
-        },
-    ))
+    alt((
+        value(TimeUnit::Hour, char('h')),
+        value(TimeUnit::Day, char('d')),
+        value(TimeUnit::Week, char('w')),
+        value(TimeUnit::Month, char('m')),
+        value(TimeUnit::Year, char('y')),
+    ))(input)
 }
 
 fn parse_interval(input: &str) -> IResult<&str, (usize, TimeUnit), ()> {

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -151,6 +151,27 @@ pub enum Timestamp<'a> {
     },
 }
 
+impl fmt::Display for Timestamp<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Timestamp::Active { start, .. } => {
+                write!(f, "<{}>", start)?;
+            }
+            Timestamp::Inactive { start, .. } => {
+                write!(f, "[{}]", start)?;
+            }
+            Timestamp::ActiveRange { start, end, .. } => {
+                write!(f, "<{}>--<{}>", start, end)?;
+            }
+            Timestamp::InactiveRange { start, end, .. } => {
+                write!(f, "<{}>--<{}>", start, end)?;
+            }
+            Timestamp::Diary { value } => write!(f, "<%%({})>", value)?,
+        }
+        Ok(())
+    }
+}
+
 impl Timestamp<'_> {
     pub(crate) fn parse_active(input: &str) -> Option<(&str, Timestamp)> {
         parse_active(input).ok()

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -6,12 +6,10 @@ use nom::{
     branch::{alt, permutation},
     bytes::complete::{tag, take, take_until, take_while1, take_while_m_n},
     character::complete::{char, digit1, space0, space1},
-    combinator::{map, map_res, opt, value, verify},
+    combinator::{all_consuming, map, map_res, opt, value, verify},
     sequence::{delimited, preceded, separated_pair},
     IResult,
 };
-
-use crate::parsers::{helper_for_parse_element, Parse};
 
 /// Datetime Struct
 #[cfg_attr(test, derive(PartialEq))]
@@ -88,7 +86,18 @@ impl fmt::Display for RepeaterMark {
 impl TryFrom<&str> for RepeaterMark {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        helper_for_parse_element(parse_repeater_mark(s)).ok_or(())
+        all_consuming(parse_repeater_mark)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl TryFrom<String> for RepeaterMark {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_repeater_mark)(&s)
+            .map(|e| e.1)
+            .map_err(|_| ())
     }
 }
 
@@ -110,7 +119,18 @@ impl fmt::Display for DelayMark {
 impl TryFrom<&str> for DelayMark {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        helper_for_parse_element(parse_delay_mark(s)).ok_or(())
+        all_consuming(parse_delay_mark)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl TryFrom<String> for DelayMark {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_delay_mark)(&s)
+            .map(|e| e.1)
+            .map_err(|_| ())
     }
 }
 
@@ -141,7 +161,18 @@ impl fmt::Display for TimeUnit {
 impl TryFrom<&str> for TimeUnit {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        helper_for_parse_element(parse_time_unit(s)).ok_or(())
+        all_consuming(parse_time_unit)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl TryFrom<String> for TimeUnit {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_time_unit)(&s)
+            .map(|e| e.1)
+            .map_err(|_| ())
     }
 }
 
@@ -154,7 +185,18 @@ impl fmt::Display for Repeater {
 impl TryFrom<&str> for Repeater {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        helper_for_parse_element(parse_repeater(s)).ok_or(())
+        all_consuming(parse_repeater)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl TryFrom<String> for Repeater {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_repeater)(&s)
+            .map(|e| e.1)
+            .map_err(|_| ())
     }
 }
 
@@ -167,7 +209,14 @@ impl fmt::Display for Delay {
 impl TryFrom<&str> for Delay {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        helper_for_parse_element(parse_delay(s)).ok_or(())
+        all_consuming(parse_delay)(s).map(|e| e.1).map_err(|_| ())
+    }
+}
+
+impl TryFrom<String> for Delay {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_delay)(&s).map(|e| e.1).map_err(|_| ())
     }
 }
 
@@ -184,9 +233,21 @@ impl fmt::Display for Datetime<'_> {
     }
 }
 
-impl<'a> Parse<'a> for Datetime<'a> {
-    fn parse(s: &'a str) -> Option<Datetime<'a>> {
-        helper_for_parse_element(parse_datetime(s))
+impl<'a> TryFrom<&'a str> for Datetime<'a> {
+    type Error = ();
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        all_consuming(parse_datetime)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl<'a> TryFrom<String> for Datetime<'static> {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_datetime)(&s)
+            .map(|e| e.1.into_owned())
+            .map_err(|_| ())
     }
 }
 
@@ -490,9 +551,21 @@ impl Timestamp<'_> {
     }
 }
 
-impl<'a> Parse<'a> for Timestamp<'a> {
-    fn parse(s: &'a str) -> Option<Timestamp<'a>> {
-        helper_for_parse_element(parse_timestamp(s))
+impl<'a> TryFrom<&'a str> for Timestamp<'a> {
+    type Error = ();
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        all_consuming(parse_timestamp)(s)
+            .map(|e| e.1)
+            .map_err(|_| ())
+    }
+}
+
+impl<'a> TryFrom<String> for Timestamp<'static> {
+    type Error = ();
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        all_consuming(parse_timestamp)(&s)
+            .map(|e| e.1.into_owned())
+            .map_err(|_| ())
     }
 }
 
@@ -1309,7 +1382,7 @@ fn test_format_datetime() {
         "2025-09-09 Mon 03:05",
         "2025-09-09 03:05",
     ] {
-        assert_eq!(*s, Datetime::parse(*s).unwrap().to_string());
+        assert_eq!(*s, Datetime::try_from(*s).unwrap().to_string());
     }
 }
 
@@ -1332,31 +1405,33 @@ fn test_format_timestamp() {
         "[1991-01-01 Mon 03:55]--[1992-02-03 Tue]",
         "<1991-01-01 Mon 03:55 +1d -1w>--<1992-02-03 Tue +2w -2d>",
     ] {
-        assert_eq!(*s, Timestamp::parse(s).unwrap().to_string());
+        assert_eq!(*s, Timestamp::try_from(*s).unwrap().to_string());
     }
 
     assert_eq!(
         "<1991-01-01 Mon 03:55-04:00>",
-        Timestamp::parse("<1991-01-01 Mon 03:55>--<1991-01-01 Mon 04:00>")
+        Timestamp::try_from("<1991-01-01 Mon 03:55>--<1991-01-01 Mon 04:00>")
             .unwrap()
             .to_string()
     );
 
     assert_eq!(
         "<1991-01-01 +1d -1w>",
-        Timestamp::parse("<1991-01-01 -1w +1d>")
+        Timestamp::try_from("<1991-01-01 -1w +1d>")
             .unwrap()
             .to_string()
     );
 
     assert_eq!(
         "<1991-01-01 05:05>",
-        Timestamp::parse("<1991-01-01 5:05>").unwrap().to_string()
+        Timestamp::try_from("<1991-01-01 5:05>")
+            .unwrap()
+            .to_string()
     );
 
     assert_eq!(
         "<1991-01-01 05:05-07:09>",
-        Timestamp::parse("<1991-1-1 5:05-7:09>")
+        Timestamp::try_from("<1991-1-1 5:05-7:09>")
             .unwrap()
             .to_string()
     );

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 
 use nom::{
     bytes::complete::{tag, take, take_till, take_while, take_while_m_n},
@@ -21,6 +22,20 @@ pub struct Datetime<'a> {
     pub hour: Option<u8>,
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
     pub minute: Option<u8>,
+}
+
+impl fmt::Display for Datetime<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02} {}",
+            self.year, self.month, self.day, self.dayname
+        )?;
+        if let (Some(hour), Some(minute)) = (self.hour, self.minute) {
+            write!(f, " {:02}:{:02}", hour, minute)?;
+        }
+        Ok(())
+    }
 }
 
 impl Datetime<'_> {

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -4,7 +4,6 @@ use std::io::{Error, Result as IOResult, Write};
 use jetscii::{bytes, BytesConst};
 
 use crate::elements::{Element, Table, TableCell, TableRow, Timestamp};
-use crate::export::write_datetime;
 
 /// A wrapper for escaping sensitive characters in html.
 ///
@@ -144,18 +143,16 @@ impl HtmlHandler<Error> for DefaultHtmlHandler {
 
                 match timestamp {
                     Timestamp::Active { start, .. } => {
-                        write_datetime(&mut w, "&lt;", start, "&gt;")?;
+                        write!(&mut w, "&lt;{}&gt;", start)?;
                     }
                     Timestamp::Inactive { start, .. } => {
-                        write_datetime(&mut w, "[", start, "]")?;
+                        write!(&mut w, "[{}]", start)?;
                     }
                     Timestamp::ActiveRange { start, end, .. } => {
-                        write_datetime(&mut w, "&lt;", start, "&gt;&#x2013;")?;
-                        write_datetime(&mut w, "&lt;", end, "&gt;")?;
+                        write!(&mut w, "&lt;{}&gt;&#<2013;&lt;{}&gt;", start, end)?;
                     }
                     Timestamp::InactiveRange { start, end, .. } => {
-                        write_datetime(&mut w, "[", start, "]&#x2013;")?;
-                        write_datetime(&mut w, "[", end, "]")?;
+                        write!(&mut w, "&lt;{}&gt;&#<2013;&lt;{}&gt;", start, end)?;
                     }
                     Timestamp::Diary { value } => {
                         write!(&mut w, "&lt;%%({})&gt;", HtmlEscape(value))?

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -7,25 +7,3 @@ mod org;
 pub use html::SyntectHtmlHandler;
 pub use html::{DefaultHtmlHandler, HtmlEscape, HtmlHandler};
 pub use org::{DefaultOrgHandler, OrgHandler};
-
-use std::io::{Error, Write};
-
-use crate::elements::Datetime;
-
-pub(crate) fn write_datetime<W: Write>(
-    mut w: W,
-    start: &str,
-    datetime: &Datetime,
-    end: &str,
-) -> Result<(), Error> {
-    write!(w, "{}", start)?;
-    write!(
-        w,
-        "{}-{:02}-{:02} {}",
-        datetime.year, datetime.month, datetime.day, datetime.dayname
-    )?;
-    if let (Some(hour), Some(minute)) = (datetime.hour, datetime.minute) {
-        write!(w, " {:02}:{:02}", hour, minute)?;
-    }
-    write!(w, "{}", end)
-}

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::io::{Error, Result as IOResult, Write};
 
 use crate::elements::{Clock, Element, Table, Timestamp};
@@ -125,7 +126,7 @@ impl OrgHandler<Error> for DefaultOrgHandler {
             Element::Target(_target) => (),
             Element::Text { value } => write!(w, "{}", value)?,
             Element::Timestamp(timestamp) => {
-                write_timestamp(&mut w, &timestamp)?;
+                write!(&mut w, "{}", timestamp)?;
             }
             Element::Verbatim { value } => write!(w, "={}=", value)?,
             Element::FnDef(fn_def) => {
@@ -245,22 +246,19 @@ impl OrgHandler<Error> for DefaultOrgHandler {
                 writeln!(&mut w)?;
                 if let Some(planning) = &title.planning {
                     if let Some(scheduled) = &planning.scheduled {
-                        write!(&mut w, "SCHEDULED: ")?;
-                        write_timestamp(&mut w, &scheduled)?;
+                        write!(&mut w, "SCHEDULED: {}", &scheduled)?;
                     }
                     if let Some(deadline) = &planning.deadline {
                         if planning.scheduled.is_some() {
                             write!(&mut w, " ")?;
                         }
-                        write!(&mut w, "DEADLINE: ")?;
-                        write_timestamp(&mut w, &deadline)?;
+                        write!(&mut w, "DEADLINE: {}", &deadline)?;
                     }
                     if let Some(closed) = &planning.closed {
                         if planning.deadline.is_some() {
                             write!(&mut w, " ")?;
                         }
-                        write!(&mut w, "CLOSED: ")?;
-                        write_timestamp(&mut w, &closed)?;
+                        write!(&mut w, "CLOSED: {}", &closed)?;
                     }
                     writeln!(&mut w)?;
                 }
@@ -292,25 +290,6 @@ impl OrgHandler<Error> for DefaultOrgHandler {
 fn write_blank_lines<W: Write>(mut w: W, count: usize) -> Result<(), Error> {
     for _ in 0..count {
         writeln!(w)?;
-    }
-    Ok(())
-}
-
-fn write_timestamp<W: Write>(mut w: W, timestamp: &Timestamp) -> Result<(), Error> {
-    match timestamp {
-        Timestamp::Active { start, .. } => {
-            write!(w, "<{}>", start)?;
-        }
-        Timestamp::Inactive { start, .. } => {
-            write!(w, "[{}]", start)?;
-        }
-        Timestamp::ActiveRange { start, end, .. } => {
-            write!(w, "<{}>--<{}>", start, end)?;
-        }
-        Timestamp::InactiveRange { start, end, .. } => {
-            write!(w, "<{}>--<{}>", start, end)?;
-        }
-        Timestamp::Diary { value } => write!(w, "<%%({})>", value)?,
     }
     Ok(())
 }

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,7 +1,6 @@
 use std::io::{Error, Result as IOResult, Write};
 
 use crate::elements::{Clock, Element, Table, Timestamp};
-use crate::export::write_datetime;
 
 pub trait OrgHandler<E: From<Error>>: Default {
     fn start<W: Write>(&mut self, w: W, element: &Element) -> Result<(), E>;
@@ -143,15 +142,13 @@ impl OrgHandler<Error> for DefaultOrgHandler {
                         post_blank,
                         ..
                     } => {
-                        write_datetime(&mut w, "[", &start, "]--")?;
-                        write_datetime(&mut w, "[", &end, "]")?;
-                        writeln!(&mut w, " => {}", duration)?;
+                        writeln!(&mut w, "[{}]--[{}] => {}", &start, &end, duration)?;
                         write_blank_lines(&mut w, *post_blank)?;
                     }
                     Clock::Running {
                         start, post_blank, ..
                     } => {
-                        write_datetime(&mut w, "[", &start, "]\n")?;
+                        write!(&mut w, "[{}]\n", &start)?;
                         write_blank_lines(&mut w, *post_blank)?;
                     }
                 }
@@ -302,18 +299,16 @@ fn write_blank_lines<W: Write>(mut w: W, count: usize) -> Result<(), Error> {
 fn write_timestamp<W: Write>(mut w: W, timestamp: &Timestamp) -> Result<(), Error> {
     match timestamp {
         Timestamp::Active { start, .. } => {
-            write_datetime(w, "<", start, ">")?;
+            write!(w, "<{}>", start)?;
         }
         Timestamp::Inactive { start, .. } => {
-            write_datetime(w, "[", start, "]")?;
+            write!(w, "[{}]", start)?;
         }
         Timestamp::ActiveRange { start, end, .. } => {
-            write_datetime(&mut w, "<", start, ">--")?;
-            write_datetime(&mut w, "<", end, ">")?;
+            write!(w, "<{}>--<{}>", start, end)?;
         }
         Timestamp::InactiveRange { start, end, .. } => {
-            write_datetime(&mut w, "[", start, "]--")?;
-            write_datetime(&mut w, "[", end, "]")?;
+            write!(w, "<{}>--<{}>", start, end)?;
         }
         Timestamp::Diary { value } => write!(w, "<%%({})>", value)?,
     }

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
 use std::io::{Error, Result as IOResult, Write};
 
-use crate::elements::{Clock, Element, Table, Timestamp};
+use crate::elements::{Clock, Element, Table};
 
 pub trait OrgHandler<E: From<Error>>: Default {
     fn start<W: Write>(&mut self, w: W, element: &Element) -> Result<(), E>;
@@ -149,7 +148,7 @@ impl OrgHandler<Error> for DefaultOrgHandler {
                     Clock::Running {
                         start, post_blank, ..
                     } => {
-                        write!(&mut w, "[{}]\n", &start)?;
+                        writeln!(&mut w, "[{}]", &start)?;
                         write_blank_lines(&mut w, *post_blank)?;
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,5 +238,4 @@ pub use config::ParseConfig;
 pub use elements::Element;
 pub use headline::{Document, Headline};
 pub use org::{Event, Org};
-pub use parsers::Parse;
 pub use validate::ValidationError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,4 +238,5 @@ pub use config::ParseConfig;
 pub use elements::Element;
 pub use headline::{Document, Headline};
 pub use org::{Event, Org};
+pub use parsers::Parse;
 pub use validate::ValidationError;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,11 +1,10 @@
-use std::convert::TryFrom;
 use std::iter::once;
 use std::marker::PhantomData;
 
 use indextree::{Arena, NodeId};
 use jetscii::{bytes, BytesConst};
 use memchr::{memchr, memchr_iter};
-use nom::{bytes::complete::take_while1, IResult};
+use nom::bytes::complete::take_while1;
 
 use crate::config::ParseConfig;
 use crate::elements::{
@@ -15,22 +14,6 @@ use crate::elements::{
     TableCell, TableRow, Target, Title,
 };
 use crate::parse::combinators::lines_while;
-
-// Trait for elements which can be parsed from a string, but retain a lifetime
-// dependence on the string, precluding the use of FromStr or TryFrom.
-pub trait Parse<'a> {
-    fn parse(s: &'a str) -> Option<Self>
-    where
-        Self: Sized + 'a;
-}
-
-// Convenience implementation of Parse for any type which implements
-// TryFrom<&str> without a lifetime dependence on the string.
-impl<T: TryFrom<&'static str>> Parse<'static> for T {
-    fn parse(s: &'static str) -> Option<T> {
-        T::try_from(s).ok()
-    }
-}
 
 pub trait ElementArena<'a> {
     fn append<T>(&mut self, element: T, parent: NodeId) -> NodeId
@@ -665,18 +648,6 @@ pub fn parse_headline_level(input: &str) -> Option<(&str, usize)> {
 
     if input.starts_with(' ') || input.starts_with('\n') || input.is_empty() {
         Some((input, stars.len()))
-    } else {
-        None
-    }
-}
-
-// Helper to cut down on boilerplate that converts from nom parsing to a
-// user-friendly conversion function, and fails the parse if any characters are
-// left over at the end.
-pub(crate) fn helper_for_parse_element<T>(parsed: IResult<&str, T, ()>) -> Option<T> {
-    let (input, element) = parsed.ok()?;
-    if input.is_empty() {
-        Some(element)
     } else {
         None
     }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -9,9 +9,9 @@ use nom::bytes::complete::take_while1;
 use crate::config::ParseConfig;
 use crate::elements::{
     block::RawBlock, emphasis::Emphasis, keyword::RawKeyword, radio_target::parse_radio_target,
-    Clock, Comment, Cookie, Drawer, DynBlock, Element, FixedWidth, FnDef, FnRef, InlineCall,
-    InlineSrc, Link, List, ListItem, Macros, Rule, Snippet, Table, TableCell, TableRow, Target,
-    Timestamp, Title,
+    timestamp::parse_timestamp, Clock, Comment, Cookie, Drawer, DynBlock, Element, FixedWidth,
+    FnDef, FnRef, InlineCall, InlineSrc, Link, List, ListItem, Macros, Rule, Snippet, Table,
+    TableCell, TableRow, Target, Title,
 };
 use crate::parse::combinators::lines_while;
 
@@ -461,11 +461,8 @@ pub fn parse_inline<'a, T: ElementArena<'a>>(
             } else if let Some((tail, target)) = Target::parse(contents) {
                 arena.append(target, parent);
                 Some(tail)
-            } else if let Some((tail, timestamp)) = Timestamp::parse_active(contents) {
-                arena.append(timestamp, parent);
-                Some(tail)
             } else {
-                let (tail, timestamp) = Timestamp::parse_diary(contents)?;
+                let (tail, timestamp) = parse_timestamp(contents).ok()?;
                 arena.append(timestamp, parent);
                 Some(tail)
             }
@@ -481,7 +478,7 @@ pub fn parse_inline<'a, T: ElementArena<'a>>(
                 arena.append(cookie, parent);
                 Some(tail)
             } else {
-                let (tail, timestamp) = Timestamp::parse_inactive(contents)?;
+                let (tail, timestamp) = parse_timestamp(contents).ok()?;
                 arena.append(timestamp, parent);
                 Some(tail)
             }

--- a/tests/blank.rs
+++ b/tests/blank.rs
@@ -11,7 +11,7 @@ CONTENTS
 #+END_QUOTE
 
 * Headline 1
-SCHEDULED: <2019-10-28 Mon>
+SCHEDULED: <2019-10-28 Mon +1w -1d>
 :PROPERTIES:
 :ID: headline-1
 :END:


### PR DESCRIPTION
Please review after #30 , as this is rebased on top of it.

Rework timestamp parsing in a few ways:
* Add repeaters and delays as their own types.
* Fix range types to support repeaters and delays at both start and end.
* Parse repeaters and delays.
* Make dayname optional.
* Add Parse trait to allow users to parse individual elements from a &str.
* Implement TryFrom<&str> for Parse.
* Implement Parse/TryFrom<&str> for all timestamp parts.
* Substantially increase timestamp test coverage for new and existing cases.