### PR TITLE
Fix drawer parsing to not take headlines

### DIFF
--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -453,5 +453,5 @@ fn parse_properties_drawer_() {
                 .into_iter()
                 .collect::<HashMap<_, _>>()
         ))
-    )
+    );
 }

--- a/tests/issue_24.rs
+++ b/tests/issue_24.rs
@@ -1,0 +1,18 @@
+use orgize::Org;
+
+#[test]
+fn headline_in_drawer() {
+    // https://github.com/PoiScript/orgize/issues/24
+    // A drawer may not contain a headline.
+    const STARS: &str = "****";
+    for h1 in 1..STARS.len() {
+        for h2 in 1..STARS.len() {
+            let org = crate::Org::parse_string(format!(
+                "{} Hello\n:PROPERTIES:\n{} World\n:END:",
+                &STARS[..h1],
+                &STARS[..h2]
+            ));
+            assert_eq!(org.headlines().count(), 2);
+        }
+    }
+}


### PR DESCRIPTION
Please review after #34 .

Currently, when parsing a drawer for a node of level N, any headlines of level N + 1 will be absorbed into the drawer. This changes drawer parsing to reject headlines. For example:

```
* Hello
:PROPERTIES:
** World
:END:
```

should be parsed as two nodes. The drawer is ill-formed, and will be parsed as part of the body instead of as a drawer. 

This will fix #24 .