### PR TITLE
Compilation issue from dependency: jetscii v0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,20 +20,20 @@ default = ["ser"]
 ser = ["serde", "serde_indextree", "indexmap/serde-1"]
 
 [dependencies]
-bytecount = "0.6.0"
-chrono = { version = "0.4.11", optional = true }
-indextree = "4.0.0"
-jetscii = "0.4.4"
+bytecount = "0.6.2"
+chrono = { version = "0.4.19", optional = true }
+indextree = "4.3.1"
+jetscii = "0.5.1"
 lazy_static = "1.4.0"
-memchr = "2.3.3"
+memchr = "2.4.1"
 # we don't need to parse any float number, so lexical crate is redundant
-nom = { version = "5.1.1", default-features = false, features = ["std"] }
-serde = { version = "1.0.106", optional = true, features = ["derive"] }
+nom = { version = "7.0.0", default-features = false, features = ["std"] }
+serde = { version = "1.0.130", optional = true, features = ["derive"] }
 serde_indextree = { version = "0.2.0", optional = true }
-syntect = { version = "4.1.0", optional = true }
-indexmap = { version = "1.3.2", features = ["serde-1"], optional = true}
+syntect = { version = "4.6.0", optional = true }
+indexmap = { version = "1.7.0", features = ["serde-1"], optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
-serde_json = "1.0.51"
+pretty_assertions = "1.0.0"
+serde_json = "1.0.68"
 slugify = "0.1.0"

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -221,7 +221,7 @@ fn parse_properties_drawer(
     }
     let (_, map) = fold_many0(
         parse_node_property,
-        PropertiesMap::new(),
+        PropertiesMap::new,
         |mut acc: PropertiesMap<_, _>, (name, value)| {
             acc.insert(name.into(), value.into());
             acc


### PR DESCRIPTION
Hi there,

This is a great library, thanks for all the work you've put into it.

## The issue

I'm trying to use this library, but I'm running into a compilation error with one of orgize's dependencies: jetscii.
I'm using orgize v0.8.4 in `Cargo.toml`, and I get this error when trying to compile:

```rust
error: generic parameters may not be used in const operations
   --> /home/james/.cargo/registry/src/github.com-1ecc6299db9ec823/jetscii-0.4.4/src/simd.rs:109:13
    |
109 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions

error: generic parameters may not be used in const operations
   --> /home/james/.cargo/registry/src/github.com-1ecc6299db9ec823/jetscii-0.4.4/src/simd.rs:148:13
    |
148 |             T::CONTROL_BYTE,
    |             ^^^^^^^^^^^^^^^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions

error: could not compile `jetscii` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```

## Possible fix

Jetscii has since updated its [MSRV to Rust 1.51](https://github.com/shepmaster/jetscii/blob/main/CHANGELOG.md#050---2021-05-05), and the issue appears fixed in version >= 0.5.0 of the library.
When I upgrade the all the package versions in `Cargo.toml`, and change [this line in `parse_properties_drawer()`](https://github.com/PoiScript/orgize/blob/e009e1c199d78e2531bed1913a6e40a0f167c2d5/src/elements/title.rs#L224) from

```rust
    let (_, map) = fold_many0(
        parse_node_property,
        PropertiesMap::new(),
        |mut acc: PropertiesMap<_, _>, (name, value)| {
            acc.insert(name.into(), value.into());
            acc
        },
    )(content)?;
```

to

```rust
    let (_, map) = fold_many0(
        parse_node_property,
        PropertiesMap::new,       // no brackets for the `init` parameter in `fold_many0`
        |mut acc: PropertiesMap<_, _>, (name, value)| {
            acc.insert(name.into(), value.into());
            acc
        },
    )(content)?;
```

Everything compiles after this change.
Based on the files I'm trying to parse, this fix works for me.

I'm not sure how version-specific the dependencies are, since I run into other compilation errors when I only upgrade jetscii's version, but not other crates.
I'm also not sure how this change fits into the broader context of the rest of the library, so I figured I'd send a PR in the hopes that you might know better.

Thanks again for the library, so far.