### PR TITLE
Update dependencies (jetscii no longer compiles on Rust 1.55)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ ser = ["serde", "serde_indextree", "indexmap/serde-1"]
 bytecount = "0.6.0"
 chrono = { version = "0.4.11", optional = true }
 indextree = "4.0.0"
-jetscii = "0.4.4"
+jetscii = "0.5.1"
 lazy_static = "1.4.0"
 memchr = "2.3.3"
 # we don't need to parse any float number, so lexical crate is redundant
-nom = { version = "5.1.1", default-features = false, features = ["std"] }
+nom = { version = "6.2.1", default-features = false, features = ["std"] }
 serde = { version = "1.0.106", optional = true, features = ["derive"] }
 serde_indextree = { version = "0.2.0", optional = true }
 syntect = { version = "4.1.0", optional = true }
 indexmap = { version = "1.3.2", features = ["serde-1"], optional = true}
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
+pretty_assertions = "1.0.0"
 serde_json = "1.0.51"
 slugify = "0.1.0"

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -495,7 +495,7 @@ fn preserve_properties_drawer_order() {
         s += &format!("   :{}: {}\n", k, v);
     }
     let drawer = format!("   :PROPERTIES:\n{}:END:\n", &s);
-    let mut parsed: Vec<(_, _)> = parse_properties_drawer(&drawer)
+    let parsed: Vec<(_, _)> = parse_properties_drawer(&drawer)
         .unwrap()
         .1
         .into_iter()

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -83,11 +83,7 @@ impl Org<'_> {
                     }
 
                     for child in children {
-                        expect_element!(
-                            child,
-                            "Headline",
-                            Element::Headline { .. }
-                        );
+                        expect_element!(child, "Headline", Element::Headline { .. });
                     }
                 }
                 Element::Headline { .. } => {
@@ -107,11 +103,7 @@ impl Org<'_> {
                     }
 
                     for child in children {
-                        expect_element!(
-                            child,
-                            "Headline",
-                            Element::Headline { .. }
-                        );
+                        expect_element!(child, "Headline", Element::Headline { .. });
                     }
                 }
                 Element::Title(title) => {


### PR DESCRIPTION
It wasn't possible to build orgize on Rust 1.55 due to its dependency jetscii - version 0.4.4 does not compile on Rust 1.55, version 0.5.1 does. While i was at it, i also updated other dependencies as far as they compiled on 1.55.

The PR also fixes rustfmt issue to pass the CI, and removes an unnecessary `mut`.