### PR TITLE
derive `PartialEq`

### DIFF
--- a/src/elements/block.rs
+++ b/src/elements/block.rs
@@ -11,8 +11,7 @@ use crate::elements::Element;
 use crate::parse::combinators::{blank_lines_count, line, lines_till};
 
 /// Special Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SpecialBlock<'a> {
     /// Block parameters
@@ -40,8 +39,7 @@ impl SpecialBlock<'_> {
 }
 
 /// Quote Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct QuoteBlock<'a> {
     /// Optional block parameters
@@ -66,8 +64,7 @@ impl QuoteBlock<'_> {
 }
 
 /// Center Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct CenterBlock<'a> {
     /// Optional block parameters
@@ -92,8 +89,7 @@ impl CenterBlock<'_> {
 }
 
 /// Verse Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct VerseBlock<'a> {
     /// Optional block parameters
@@ -118,8 +114,7 @@ impl VerseBlock<'_> {
 }
 
 /// Comment Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct CommentBlock<'a> {
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
@@ -142,8 +137,7 @@ impl CommentBlock<'_> {
 }
 
 /// Example Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ExampleBlock<'a> {
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]
@@ -166,8 +160,7 @@ impl ExampleBlock<'_> {
 }
 
 /// Export Block Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ExportBlock<'a> {
     pub data: Cow<'a, str>,
@@ -189,8 +182,7 @@ impl ExportBlock<'_> {
 }
 
 /// Src Block Element
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SourceBlock<'a> {
     ///  Block contents
@@ -220,8 +212,7 @@ impl SourceBlock<'_> {
     // TODO: fn retain_labels() -> bool {  }
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 pub(crate) struct RawBlock<'a> {
     pub name: &'a str,
     pub arguments: &'a str,

--- a/src/elements/clock.rs
+++ b/src/elements/clock.rs
@@ -12,10 +12,9 @@ use crate::elements::timestamp::{parse_inactive, Datetime, Timestamp};
 use crate::parse::combinators::{blank_lines_count, eol};
 
 /// Clock Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(untagged))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Clock<'a> {
     /// Closed Clock
     Closed {

--- a/src/elements/comment.rs
+++ b/src/elements/comment.rs
@@ -7,7 +7,7 @@ use nom::{
 
 use crate::parse::combinators::{blank_lines_count, lines_while};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Comment<'a> {
     /// Comments value, with pound signs

--- a/src/elements/cookie.rs
+++ b/src/elements/cookie.rs
@@ -10,9 +10,8 @@ use nom::{
 };
 
 /// Statistics Cookie Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Cookie<'a> {
     /// Full cookie value
     pub value: Cow<'a, str>,

--- a/src/elements/drawer.rs
+++ b/src/elements/drawer.rs
@@ -10,8 +10,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, eol, lines_till};
 
 /// Drawer Element
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Drawer<'a> {
     /// Drawer name

--- a/src/elements/dyn_block.rs
+++ b/src/elements/dyn_block.rs
@@ -9,8 +9,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, line, lines_till};
 
 /// Dynamic Block Element
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct DynBlock<'a> {
     /// Block name

--- a/src/elements/emphasis.rs
+++ b/src/elements/emphasis.rs
@@ -3,8 +3,7 @@ use memchr::memchr_iter;
 
 use crate::elements::Element;
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Emphasis<'a> {
     marker: u8,
     contents: &'a str,

--- a/src/elements/fixed_width.rs
+++ b/src/elements/fixed_width.rs
@@ -7,8 +7,7 @@ use nom::{
 
 use crate::parse::combinators::{blank_lines_count, lines_while};
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct FixedWidth<'a> {
     /// Fixed width value

--- a/src/elements/fn_def.rs
+++ b/src/elements/fn_def.rs
@@ -9,9 +9,8 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, line};
 
 /// Footnote Definition Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct FnDef<'a> {
     /// Footnote label, used for reference
     pub label: Cow<'a, str>,

--- a/src/elements/fn_ref.rs
+++ b/src/elements/fn_ref.rs
@@ -10,9 +10,8 @@ use nom::{
 };
 
 /// Footnote Reference Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FnRef<'a> {
     /// Footnote label
     pub label: Cow<'a, str>,

--- a/src/elements/inline_call.rs
+++ b/src/elements/inline_call.rs
@@ -8,9 +8,8 @@ use nom::{
 };
 
 /// Inline Babel Call Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct InlineCall<'a> {
     /// Called code block name
     pub name: Cow<'a, str>,

--- a/src/elements/inline_src.rs
+++ b/src/elements/inline_src.rs
@@ -8,9 +8,8 @@ use nom::{
 };
 
 /// Inline Src Block Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineSrc<'a> {
     /// Language of the code
     pub lang: Cow<'a, str>,

--- a/src/elements/keyword.rs
+++ b/src/elements/keyword.rs
@@ -12,9 +12,8 @@ use crate::elements::Element;
 use crate::parse::combinators::{blank_lines_count, line};
 
 /// Keyword Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Keyword<'a> {
     /// Keyword name
     pub key: Cow<'a, str>,
@@ -39,8 +38,7 @@ impl Keyword<'_> {
 }
 
 /// Babel Call Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct BabelCall<'a> {
     /// Babel call value
@@ -59,8 +57,7 @@ impl BabelCall<'_> {
     }
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 pub(crate) struct RawKeyword<'a> {
     pub key: &'a str,
     pub value: &'a str,

--- a/src/elements/link.rs
+++ b/src/elements/link.rs
@@ -8,9 +8,8 @@ use nom::{
 };
 
 /// Link Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Link<'a> {
     /// Link destination
     pub path: Cow<'a, str>,

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -12,9 +12,8 @@ use nom::{
 };
 
 /// Plain List Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct List {
     /// List indent, number of whitespaces
     pub indent: usize,
@@ -26,9 +25,8 @@ pub struct List {
 }
 
 /// List Item Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ListItem<'a> {
     /// List item bullet
     pub bullet: Cow<'a, str>,

--- a/src/elements/macros.rs
+++ b/src/elements/macros.rs
@@ -8,9 +8,8 @@ use nom::{
 };
 
 /// Macro Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Macros<'a> {
     /// Macro name
     pub name: Cow<'a, str>,

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -56,7 +56,7 @@ pub use self::{
 use std::borrow::Cow;
 
 /// Element Enum
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "type", rename_all = "kebab-case"))]
 pub enum Element<'a> {

--- a/src/elements/planning.rs
+++ b/src/elements/planning.rs
@@ -3,9 +3,8 @@ use memchr::memchr;
 use crate::elements::Timestamp;
 
 /// Planning element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Planning<'a> {
     /// Timestamp associated to deadline keyword
     #[cfg_attr(feature = "ser", serde(skip_serializing_if = "Option::is_none"))]

--- a/src/elements/rule.rs
+++ b/src/elements/rule.rs
@@ -2,8 +2,7 @@ use nom::{bytes::complete::take_while_m_n, character::complete::space0, IResult}
 
 use crate::parse::combinators::{blank_lines_count, eol};
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Rule {
     /// Numbers of blank lines between rule line and next non-blank line or

--- a/src/elements/snippet.rs
+++ b/src/elements/snippet.rs
@@ -7,9 +7,8 @@ use nom::{
 };
 
 /// Export Snippet Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Snippet<'a> {
     /// Back-end name
     pub name: Cow<'a, str>,

--- a/src/elements/table.rs
+++ b/src/elements/table.rs
@@ -8,8 +8,7 @@ use nom::{
 use crate::parse::combinators::{blank_lines_count, line, lines_while};
 
 /// Table Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_type"))]
 pub enum Table<'a> {
@@ -113,8 +112,7 @@ impl Table<'_> {
 /// |-----+-----+-----| <- ignores
 /// ```
 ///
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_row_type"))]
 #[cfg_attr(feature = "ser", serde(rename_all = "kebab-case"))]
@@ -130,8 +128,7 @@ pub enum TableRow {
 }
 
 /// Table Cell Element
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "table_cell_type"))]
 #[cfg_attr(feature = "ser", serde(rename_all = "kebab-case"))]

--- a/src/elements/target.rs
+++ b/src/elements/target.rs
@@ -8,9 +8,8 @@ use nom::{
 };
 
 /// Target Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Target<'a> {
     /// Target ID
     pub target: Cow<'a, str>,

--- a/src/elements/timestamp.rs
+++ b/src/elements/timestamp.rs
@@ -9,9 +9,8 @@ use nom::{
 };
 
 /// Datetime Struct
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Datetime<'a> {
     pub year: u16,
     pub month: u8,
@@ -95,11 +94,10 @@ mod chrono {
 }
 
 /// Timestamp Object
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(rename_all = "kebab-case"))]
 #[cfg_attr(feature = "ser", serde(tag = "timestamp_type"))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Timestamp<'a> {
     Active {
         start: Datetime<'a>,

--- a/src/elements/title.rs
+++ b/src/elements/title.rs
@@ -22,9 +22,8 @@ use crate::{
 };
 
 /// Title Element
-#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Title<'a> {
     /// Headline level, number of stars
     pub level: usize,
@@ -124,8 +123,7 @@ impl Default for Title<'_> {
 }
 
 /// Properties
-#[derive(Default, Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Default, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct PropertiesMap<'a> {
     pub pairs: Vec<(Cow<'a, str>, Cow<'a, str>)>,


### PR DESCRIPTION
allow to easily extract `indextree::NodeId` from `indextree::Node<Element>`, since `Arena<T>.get_node_id` has `where T: PartialEq` trait bound (https://docs.rs/indextree/latest/indextree/struct.Arena.html#method.get_node_id)
```rust
fn main() {
    let input = orgize::Org::parse("* ASD\ntext");
    let arena = input.arena();

    for node in arena.iter() {
        let id: indextree::NodeId = arena.get_node_id(&node).unwrap();
        println!("{}", id);
    }
}
```
```console
$ cargo run
1
2
3
4
5
6
7
```

Edit: users of library crates, usually expect to be able to clone, compare, display, debug, and use stuff as a key in hashmaps (https://rust-lang.github.io/api-guidelines/interoperability.html)