### PR TITLE
Update README.md: Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ impl HtmlHandler<MyError> for MyHtmlHandler {
 fn main() -> Result<(), MyError> {
     let mut writer = Vec::new();
     let mut handler = MyHtmlHandler::default();
-    Org::parse("* title\n*section*").wirte_html_custom(&mut writer, &mut handler)?;
+    Org::parse("* title\n*section*").write_html_custom(&mut writer, &mut handler)?;
 
     assert_eq!(
         String::from_utf8(writer)?,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ assert_eq!(
 ## Render html with custom `HtmlHandler`
 
 To customize html rendering, simply implementing `HtmlHandler` trait and passing
-it to the `Org::wirte_html_custom` function.
+it to the `Org::write_html_custom` function.
 
 The following code demonstrates how to add a id for every headline and return
 own error type while rendering.


### PR DESCRIPTION
method `write_html_custom` was misspelled as `wirte_html_custom`.