### PR TITLE
Extract exporters into a common trait

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -5,7 +5,7 @@ use std::io::{Error as IOError, Write};
 use std::result::Result;
 use std::string::FromUtf8Error;
 
-use orgize::export::{DefaultHtmlHandler, HtmlHandler};
+use orgize::export::{DefaultHtmlHandler, ExportHandler};
 use orgize::{Element, Org};
 use slugify::slugify;
 
@@ -32,7 +32,7 @@ impl From<FromUtf8Error> for MyError {
 #[derive(Default)]
 struct MyHtmlHandler(DefaultHtmlHandler);
 
-impl HtmlHandler<MyError> for MyHtmlHandler {
+impl ExportHandler<MyError> for MyHtmlHandler {
     fn start<W: Write>(&mut self, mut w: W, element: &Element) -> Result<(), MyError> {
         if let Element::Title(title) = element {
             if title.level > 6 {
@@ -72,7 +72,7 @@ fn main() -> Result<(), MyError> {
 
         let mut writer = Vec::new();
         let mut handler = MyHtmlHandler::default();
-        Org::parse(&contents).write_html_custom(&mut writer, &mut handler)?;
+        Org::parse(&contents).write(&mut writer, &mut handler)?;
 
         println!("{}", String::from_utf8(writer)?);
     }

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -54,7 +54,7 @@ impl<S: AsRef<str>> fmt::Display for HtmlEscape<S> {
 pub struct DefaultHtmlHandler;
 
 impl ExportHandler<Error> for DefaultHtmlHandler {
-    fn start<W: Write>(&mut self, mut w: W, element: &Element) -> IOResult<()> {
+    fn start<W: Write>(&mut self, mut w: W, element: &Element, _ancestors: Vec<&Element>) -> IOResult<()> {
         match element {
             // container elements
             Element::SpecialBlock(_) => (),
@@ -199,7 +199,7 @@ impl ExportHandler<Error> for DefaultHtmlHandler {
         Ok(())
     }
 
-    fn end<W: Write>(&mut self, mut w: W, element: &Element) -> IOResult<()> {
+    fn end<W: Write>(&mut self, mut w: W, element: &Element, _ancestors: Vec<&Element>) -> IOResult<()> {
         match element {
             // container elements
             Element::SpecialBlock(_) => (),

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -5,12 +5,18 @@ mod org;
 
 #[cfg(feature = "syntect")]
 pub use html::SyntectHtmlHandler;
-pub use html::{DefaultHtmlHandler, HtmlEscape, HtmlHandler};
-pub use org::{DefaultOrgHandler, OrgHandler};
+pub use html::{DefaultHtmlHandler, HtmlEscape};
+pub use org::{DefaultOrgHandler};
 
 use std::io::{Error, Write};
 
-use crate::elements::Datetime;
+use crate::elements::{Datetime, Element};
+
+pub trait ExportHandler<E: From<Error>>: Default {
+    fn start<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
+    fn end<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
+}
+
 
 pub(crate) fn write_datetime<W: Write>(
     mut w: W,

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -12,7 +12,7 @@ use std::io::{Error, Write};
 
 use crate::elements::{Datetime, Element};
 
-pub trait ExportHandler<E: From<Error>>: Default {
+pub trait ExportHandler<E: From<Error>> {
     fn start<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
     fn end<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
 }

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -13,8 +13,8 @@ use std::io::{Error, Write};
 use crate::elements::{Datetime, Element};
 
 pub trait ExportHandler<E: From<Error>> {
-    fn start<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
-    fn end<W: Write>(&mut self, writer: W, element: &Element) -> Result<(), E>;
+    fn start<W: Write>(&mut self, writer: W, element: &Element, ancestors: Vec<&Element>) -> Result<(), E>;
+    fn end<W: Write>(&mut self, writer: W, element: &Element, ancestors: Vec<&Element>) -> Result<(), E>;
 }
 
 

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -1,17 +1,12 @@
 use std::io::{Error, Result as IOResult, Write};
 
 use crate::elements::{Clock, Element, Table, Timestamp};
-use crate::export::write_datetime;
-
-pub trait OrgHandler<E: From<Error>>: Default {
-    fn start<W: Write>(&mut self, w: W, element: &Element) -> Result<(), E>;
-    fn end<W: Write>(&mut self, w: W, element: &Element) -> Result<(), E>;
-}
+use crate::export::{write_datetime, ExportHandler};
 
 #[derive(Default)]
 pub struct DefaultOrgHandler;
 
-impl OrgHandler<Error> for DefaultOrgHandler {
+impl ExportHandler<Error> for DefaultOrgHandler {
     fn start<W: Write>(&mut self, mut w: W, element: &Element) -> IOResult<()> {
         match element {
             // container elements

--- a/src/export/org.rs
+++ b/src/export/org.rs
@@ -7,7 +7,7 @@ use crate::export::{write_datetime, ExportHandler};
 pub struct DefaultOrgHandler;
 
 impl ExportHandler<Error> for DefaultOrgHandler {
-    fn start<W: Write>(&mut self, mut w: W, element: &Element) -> IOResult<()> {
+    fn start<W: Write>(&mut self, mut w: W, element: &Element, _ancestors: Vec<&Element>) -> IOResult<()> {
         match element {
             // container elements
             Element::SpecialBlock(block) => {
@@ -192,7 +192,7 @@ impl ExportHandler<Error> for DefaultOrgHandler {
         Ok(())
     }
 
-    fn end<W: Write>(&mut self, mut w: W, element: &Element) -> IOResult<()> {
+    fn end<W: Write>(&mut self, mut w: W, element: &Element, _ancestors: Vec<&Element>) -> IOResult<()> {
         match element {
             // container elements
             Element::SpecialBlock(block) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,13 +74,13 @@
 //! );
 //! ```
 //!
-//! # Render html with custom `HtmlHandler`
+//! # Render html with custom `ExportHandler`
 //!
-//! To customize html rendering, simply implementing [`HtmlHandler`] trait and passing
-//! it to the [`Org::write_html_custom`] function.
+//! To customize html rendering, simply implementing [`ExportHandler`] trait and passing
+//! it to the [`Org::write`] function.
 //!
-//! [`HtmlHandler`]: export/trait.HtmlHandler.html
-//! [`Org::write_html_custom`]: struct.Org.html#method.write_html_custom
+//! [`ExportHandler`]: export/trait.ExportHandler.html
+//! [`Org::write`]: struct.Org.html#method.write
 //!
 //! The following code demonstrates how to add a id for every headline and return
 //! own error type while rendering.
@@ -90,7 +90,7 @@
 //! use std::io::{Error as IOError, Write};
 //! use std::string::FromUtf8Error;
 //!
-//! use orgize::export::{DefaultHtmlHandler, HtmlHandler};
+//! use orgize::export::{DefaultHtmlHandler, ExportHandler};
 //! use orgize::{Element, Org};
 //! use slugify::slugify;
 //!
@@ -117,7 +117,7 @@
 //! #[derive(Default)]
 //! struct MyHtmlHandler(DefaultHtmlHandler);
 //!
-//! impl HtmlHandler<MyError> for MyHtmlHandler {
+//! impl ExportHandler<MyError> for MyHtmlHandler {
 //!     fn start<W: Write>(&mut self, mut w: W, element: &Element) -> Result<(), MyError> {
 //!         if let Element::Title(title) = element {
 //!             if title.level > 6 {
@@ -150,7 +150,7 @@
 //! fn main() -> Result<(), MyError> {
 //!     let mut writer = Vec::new();
 //!     let mut handler = MyHtmlHandler::default();
-//!     Org::parse("* title\n*section*").write_html_custom(&mut writer, &mut handler)?;
+//!     Org::parse("* title\n*section*").write(&mut writer, &mut handler)?;
 //!
 //!     assert_eq!(
 //!         String::from_utf8(writer)?,


### PR DESCRIPTION
This should fix #64 #66 

This will allow folks to write a custom exporter without having to re-implement the write logic, as well as reduces code duplication within the two exporters.