### PR TITLE
feat: adds footnote support

### DIFF
--- a/development.md
+++ b/development.md
@@ -3,7 +3,7 @@
 ```shell
 cargo fmt -- --check
 cargo test --all-features
-cargo clippy --allow-dirty --allow-staged
+cargo clippy --fix --lib -p orgize --allow-dirty --allow-staged
 ```
 
 ## Update snapshot testing
@@ -18,8 +18,8 @@ cargo insta review
 
 ```shell
 cargo install cargo-fuzz
-rustup default nightly
-cargo fuzz run fuzz_target_1
+rustup toolchain install nightly
+cargo +nightly fuzz run fuzz_target_1
 ```
 
 ## Benchmark

--- a/src/ast/generate.js
+++ b/src/ast/generate.js
@@ -103,6 +103,16 @@ const nodes = [
   {
     struct: "FnDef",
     kind: ["FN_DEF"],
+    token: [
+      ["label", "FN_LABEL"],
+      ["description", "FN_CONTENT"],
+    ],
+    post_blank: true,
+    affiliated_keywords: true,
+  },
+  {
+    struct: "FnContent",
+    kind: ["FN_CONTENT"],
     post_blank: true,
     affiliated_keywords: true,
   },
@@ -188,6 +198,7 @@ const nodes = [
   {
     struct: "FnRef",
     kind: ["FN_REF"],
+    token: [["label", "FN_LABEL"]],
   },
   {
     struct: "Macros",

--- a/src/ast/generated.rs
+++ b/src/ast/generated.rs
@@ -847,6 +847,70 @@ impl FnDef {
     pub fn raw(&self) -> String {
         self.syntax.to_string()
     }
+    pub fn label(&self) -> Option<super::Token> {
+        super::token(&self.syntax, FN_LABEL)
+    }
+    pub fn description(&self) -> Option<super::Token> {
+        super::token(&self.syntax, FN_CONTENT)
+    }
+    pub fn post_blank(&self) -> usize {
+        super::blank_lines(&self.syntax)
+    }
+    pub fn caption(&self) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| k == "CAPTION")
+    }
+    pub fn header(&self) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| k == "HEADER")
+    }
+    pub fn name(&self) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| k == "NAME")
+    }
+    pub fn plot(&self) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| k == "PLOT")
+    }
+    pub fn results(&self) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| k == "RESULTS")
+    }
+    pub fn attr(&self, backend: &str) -> Option<AffiliatedKeyword> {
+        affiliated_keyword(&self.syntax, |k| {
+            k.starts_with("ATTR_") && &k[5..] == backend
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FnContent {
+    pub(crate) syntax: SyntaxNode,
+}
+impl AstNode for FnContent {
+    type Language = OrgLanguage;
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == FN_CONTENT
+    }
+    fn cast(node: SyntaxNode) -> Option<FnContent> {
+        Self::can_cast(node.kind()).then(|| FnContent { syntax: node })
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl FnContent {
+    /// Beginning position of this element
+    pub fn start(&self) -> TextSize {
+        self.syntax.text_range().start()
+    }
+    /// Ending position of this element
+    pub fn end(&self) -> TextSize {
+        self.syntax.text_range().end()
+    }
+    /// Range of this element
+    pub fn text_range(&self) -> TextRange {
+        self.syntax.text_range()
+    }
+    /// Raw text of this element
+    pub fn raw(&self) -> String {
+        self.syntax.to_string()
+    }
     pub fn post_blank(&self) -> usize {
         super::blank_lines(&self.syntax)
     }
@@ -1679,6 +1743,9 @@ impl FnRef {
     /// Raw text of this element
     pub fn raw(&self) -> String {
         self.syntax.to_string()
+    }
+    pub fn label(&self) -> Option<super::Token> {
+        super::token(&self.syntax, FN_LABEL)
     }
 }
 

--- a/src/export/event.rs
+++ b/src/export/event.rs
@@ -19,6 +19,7 @@ pub enum Container {
     DynBlock(DynBlock),
 
     FnDef(FnDef),
+    FnContent(FnContent),
     Comment(Comment),
     FixedWidth(FixedWidth),
     SpecialBlock(SpecialBlock),
@@ -57,6 +58,7 @@ pub enum Event {
     Text(Token),
     Macros(Macros),
     Cookie(Cookie),
+    FnLabel(Token),
     InlineCall(InlineCall),
     InlineSrc(InlineSrc),
     Clock(Clock),

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -152,7 +152,6 @@ impl Traverser for HtmlExport {
                 if let Some(parent) = c.syntax().parent() {
                     if parent.kind() == SyntaxKind::FN_REF || parent.kind() == SyntaxKind::FN_DEF {
                         let label = token(&parent, SyntaxKind::FN_LABEL).unwrap();
-                        dbg!(&label);
                         let _ = write!(&mut self.output, "id=\"footnote_{}\" ", label);
                     }
                 }

--- a/src/export/traverse.rs
+++ b/src/export/traverse.rs
@@ -181,6 +181,7 @@ pub trait Traverser {
                     DYN_BLOCK => walk!(DynBlock),
                     FN_DEF => walk!(FnDef),
                     FN_REF => walk!(FnRef),
+                    FN_CONTENT => walk!(FnContent),
                     MACROS => walk!(@Macros),
                     SNIPPET => walk!(@Snippet),
                     TIMESTAMP_ACTIVE | TIMESTAMP_INACTIVE | TIMESTAMP_DIARY => walk!(@Timestamp),
@@ -210,12 +211,17 @@ pub trait Traverser {
                     _ => {}
                 }
             }
-            SyntaxElement::Token(token) => {
-                if token.kind() == TEXT {
+            SyntaxElement::Token(token) => match token.kind() {
+                TEXT => {
                     self.event(Event::Text(Token(token)), ctx);
                     take_control!();
                 }
-            }
+                FN_LABEL => {
+                    self.event(Event::FnLabel(Token(token)), ctx);
+                    take_control!();
+                }
+                _ => {}
+            },
         };
     }
 }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -133,7 +133,7 @@ impl Org {
             ) if level <= new_level
             // non-last headline must ends with a newline
                 && (headline.end() == self.document().end()
-                    || replace_with.ends_with(&['\n', '\r'])) =>
+                    || replace_with.ends_with(['\n', '\r'])) =>
             {
                 self.replace_headline(headline, range, replace_with)
             }

--- a/src/syntax/element.rs
+++ b/src/syntax/element.rs
@@ -286,11 +286,12 @@ fn affiliated_keywords() {
           TEXT@10..25 " a footnote def"
           NEW_LINE@25..26 "\n"
         L_BRACKET@26..27 "["
-        TEXT@27..29 "fn"
+        KEYWORD@27..29 "fn"
         COLON@29..30 ":"
-        TEXT@30..34 "WORD"
+        FN_LABEL@30..34 "WORD"
         R_BRACKET@34..35 "]"
-        TEXT@35..55 " https://orgmode.org"
+        FN_CONTENT@35..55
+          TEXT@35..55 " https://orgmode.org"
     "###
     );
 

--- a/src/syntax/fn_ref.rs
+++ b/src/syntax/fn_ref.rs
@@ -31,10 +31,10 @@ fn fn_ref_node_base(input: Input) -> IResult<Input, GreenElement, ()> {
         r_bracket_token,
     ))(input)?;
 
-    let mut children = vec![l_bracket, fn_.text_token(), colon, label.text_token()];
+    let mut children = vec![l_bracket, fn_.token(KEYWORD), colon, label.token(FN_LABEL)];
     if let Some((colon, definition)) = definition {
         children.push(colon);
-        children.extend(standard_object_nodes(definition));
+        children.push(node(FN_CONTENT, standard_object_nodes(definition)));
     }
     children.push(r_bracket);
 
@@ -64,56 +64,59 @@ fn parse() {
 
     insta::assert_debug_snapshot!(
         to_fn_ref("[fn:1]").syntax,
-        @r###"
+        @r#"
     FN_REF@0..6
       L_BRACKET@0..1 "["
-      TEXT@1..3 "fn"
+      KEYWORD@1..3 "fn"
       COLON@3..4 ":"
-      TEXT@4..5 "1"
+      FN_LABEL@4..5 "1"
       R_BRACKET@5..6 "]"
-    "###
+    "#
     );
 
     insta::assert_debug_snapshot!(
         to_fn_ref("[fn:1:2]").syntax,
-        @r###"
+        @r#"
     FN_REF@0..8
       L_BRACKET@0..1 "["
-      TEXT@1..3 "fn"
+      KEYWORD@1..3 "fn"
       COLON@3..4 ":"
-      TEXT@4..5 "1"
+      FN_LABEL@4..5 "1"
       COLON@5..6 ":"
-      TEXT@6..7 "2"
+      FN_CONTENT@6..7
+        TEXT@6..7 "2"
       R_BRACKET@7..8 "]"
-    "###
+    "#
     );
 
     insta::assert_debug_snapshot!(
         to_fn_ref("[fn::2]").syntax,
-        @r###"
+        @r#"
     FN_REF@0..7
       L_BRACKET@0..1 "["
-      TEXT@1..3 "fn"
+      KEYWORD@1..3 "fn"
       COLON@3..4 ":"
-      TEXT@4..4 ""
+      FN_LABEL@4..4 ""
       COLON@4..5 ":"
-      TEXT@5..6 "2"
+      FN_CONTENT@5..6
+        TEXT@5..6 "2"
       R_BRACKET@6..7 "]"
-    "###
+    "#
     );
 
     insta::assert_debug_snapshot!(
         to_fn_ref("[fn::[]]").syntax,
-        @r###"
+        @r#"
     FN_REF@0..8
       L_BRACKET@0..1 "["
-      TEXT@1..3 "fn"
+      KEYWORD@1..3 "fn"
       COLON@3..4 ":"
-      TEXT@4..4 ""
+      FN_LABEL@4..4 ""
       COLON@4..5 ":"
-      TEXT@5..7 "[]"
+      FN_CONTENT@5..7
+        TEXT@5..7 "[]"
       R_BRACKET@7..8 "]"
-    "###
+    "#
     );
 
     let config = &ParseConfig::default();

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -199,6 +199,8 @@ pub enum SyntaxKind {
     COOKIE,
     RADIO_TARGET,
     FN_REF,
+    FN_LABEL,
+    FN_CONTENT,
     LATEX_FRAGMENT,
     MACROS,
     SNIPPET,

--- a/src/syntax/object.rs
+++ b/src/syntax/object.rs
@@ -305,7 +305,7 @@ fn parse() {
 
     insta::assert_debug_snapshot!(
         t("~org-inlinetask-min-level~[fn:oiml:The default value of \n~org-inlinetask-min-level~ is =15=.]"),
-        @r###"
+        @r#"
     PARAGRAPH@0..93
       CODE@0..26
         TILDE@0..1 "~"
@@ -313,23 +313,24 @@ fn parse() {
         TILDE@25..26 "~"
       FN_REF@26..93
         L_BRACKET@26..27 "["
-        TEXT@27..29 "fn"
+        KEYWORD@27..29 "fn"
         COLON@29..30 ":"
-        TEXT@30..34 "oiml"
+        FN_LABEL@30..34 "oiml"
         COLON@34..35 ":"
-        TEXT@35..57 "The default value of \n"
-        CODE@57..83
-          TILDE@57..58 "~"
-          TEXT@58..82 "org-inlinetask-min-level"
-          TILDE@82..83 "~"
-        TEXT@83..87 " is "
-        VERBATIM@87..91
-          EQUAL@87..88 "="
-          TEXT@88..90 "15"
-          EQUAL@90..91 "="
-        TEXT@91..92 "."
+        FN_CONTENT@35..92
+          TEXT@35..57 "The default value of \n"
+          CODE@57..83
+            TILDE@57..58 "~"
+            TEXT@58..82 "org-inlinetask-min-level"
+            TILDE@82..83 "~"
+          TEXT@83..87 " is "
+          VERBATIM@87..91
+            EQUAL@87..88 "="
+            TEXT@88..90 "15"
+            EQUAL@90..91 "="
+          TEXT@91..92 "."
         R_BRACKET@92..93 "]"
-    "###
+    "#
     );
 
     insta::assert_debug_snapshot!(

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -174,3 +174,18 @@ fn line_break() {
         @r###""<main><section><p>aa<br/>bb</p></section></main>""###
     );
 }
+
+#[test]
+fn footnote() {
+    insta::assert_debug_snapshot!(
+        Org::parse("[fn:1] In particular, the parser requires stars at column 0 to be\n").to_html(),
+        @r##""<main><section><aside class=\"footnote-definition\" ><a href=\"#footnote_1\" class=\"footnote-reference\" >[1]</a><span class=\"footnote-content\" id=\"footnote_1\" > In particular, the parser requires stars at column 0 to be</span></aside></section></main>""##
+    );
+    // "~org-inlinetask-min-level~[fn:oiml:The default value of \n~org-inlinetask-min-level~ is =15=.]"
+    insta::assert_debug_snapshot!(
+        Org::parse(
+            "~org-inlinetask-min-level~[fn:oiml:The default value of \n~org-inlinetask-min-level~ is =15=.]"
+        ).to_html(),
+        @r##""<main><section><p><code>org-inlinetask-min-level</code><a href=\"#footnote_oiml\" class=\"footnote-reference\">[oiml]</a><span class=\"footnote-content\" id=\"footnote_oiml\" >The default value of \n<code>org-inlinetask-min-level</code> is <code>15</code>.</span></p></section></main>""##
+    );
+}


### PR DESCRIPTION
## Syntax

- added node: `FN_CONTENT` 
- added token: `FN_LABEL`
- updated `fn_def()` and `fn_ref()` to use the two new syntax kinds
	- re-labelled `fn` text as keyword 

### To-do

- prune unneeded generator functions



## AST

- added `FnContent` as new AST node
- added extractors to `FnDef`, `FnRef` for label and content

## Parsing (HTML)

- added `Event` handlers 
	- `Container:FnDef`
	- `Container::FnRef`
	- `Container::FnContent` 
	- `FnLabel` 

<details>
<summary>Details</summary>

Separating out the label and the content allows extraction during HTML export. This data can then be used to generate a citations or footnotes section. 

However as of right now, `org-mode` automatically generates `org-footnotes-section` when adding footnotes, so the default HTML export process works fine, but does not apply any special treatment to the `Footnotes` heading or section.

For future work, this would be wrapped in `<aside></aside>`  or some other semantically significant tag.

</details>

## Tests

- updated insta snapshots to reflect new syntax
- added `tests/html.rs > footnote()`

## Docs

- updated commands to be more portable
