### PR TITLE
feat: permit customisation of tag characters

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,11 @@ pub struct ParseConfig {
     ///
     /// Equivalent to [`org-element-affiliated-keywords`](https://git.sr.ht/~bzg/org-mode/tree/6f960f3c6a4dfe137fbd33fef9f7dadfd229600c/item/lisp/org-element.el#L331)
     pub affiliated_keywords: Vec<String>,
+
+    /// Control tag parsing
+    ///
+    /// Defaults to org-mode's permitted characters: alphanumeric and `_@#%`.
+    pub is_tag_char: fn(char) -> bool,
 }
 
 impl ParseConfig {
@@ -82,6 +87,7 @@ impl Default for ParseConfig {
                 "SRCNAME".into(),
                 "TBLNAME".into(),
             ],
+            is_tag_char: |c| c.is_alphanumeric() || c == '_' || c == '@' || c == '#' || c == '%',
         }
     }
 }

--- a/src/syntax/headline.rs
+++ b/src/syntax/headline.rs
@@ -173,7 +173,7 @@ fn headline_tags_node(input: Input) -> IResult<Input, GreenElement, ()> {
         } else if String::from_utf8_lossy(item)
             .chars()
             // https://github.com/yyr/org-mode/blob/d8494b5668ad4d4e68e83228ae8451eaa01d2220/lisp/org-element.el#L922C25-L922C32
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '@' || c == '#' || c == '%')
+            .all(input.c.is_tag_char)
         {
             children.push(input.slice(ii + 1..i).text_token());
             children.push(token(COLON, ":"));


### PR DESCRIPTION
Org-mode frontends such as [Orgzly](https://www.orgzly.com/) are more lenient in their tag parsing, this allows us to parse org-mode files generated by such frontends.